### PR TITLE
Refactor UPRN handling to use string throughout codebase

### DIFF
--- a/src/KeeperData.Application/Orchestration/Imports/Sam/Mappings/LocationMapper.cs
+++ b/src/KeeperData.Application/Orchestration/Imports/Sam/Mappings/LocationMapper.cs
@@ -17,10 +17,8 @@ public static class LocationMapper
             getCountryById,
             cancellationToken);
 
-        int? uprn = int.TryParse(incomingAddress?.UniquePropertyReferenceNumber, out var value) ? value : null;
-
         var updatedAddress = Address.Create(
-            uprn,
+            incomingAddress?.UniquePropertyReferenceNumber,
             incomingAddress?.AddressLine ?? string.Empty,
             incomingAddress?.AddressStreet,
             incomingAddress?.AddressTown,

--- a/src/KeeperData.Core/DTOs/AddressDto.cs
+++ b/src/KeeperData.Core/DTOs/AddressDto.cs
@@ -18,7 +18,7 @@ public class AddressDto
     /// </summary>
     /// <example>671544009</example>
     [JsonPropertyName("uprn")]
-    public int? Uprn { get; set; }
+    public string? Uprn { get; set; }
 
     /// <summary>
     /// This single address line is associated with the OS Address Base Fields such as SAO_TEXT, SAO_START_NUMBER, PAO_TEXT, PAO_START_NUMBER and STREET_DESCRIPTION.

--- a/src/KeeperData.Core/Documents/AddressDocument.cs
+++ b/src/KeeperData.Core/Documents/AddressDocument.cs
@@ -1,5 +1,6 @@
 using KeeperData.Core.Domain.Shared;
 using KeeperData.Core.Repositories;
+using KeeperData.Core.Serialization;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 using System.Text.Json.Serialization;
@@ -20,8 +21,9 @@ public class AddressDocument : INestedEntity
     /// </summary>
     /// <example>6715440101</example>
     [BsonElement("uprn")]
+    [BsonSerializer(typeof(UprnSerializer))]
     [JsonPropertyName("uprn")]
-    public int? Uprn { get; set; }
+    public string? Uprn { get; set; }
 
     /// <summary>
     /// This single address line is associated with the OS Address Base Fields such as SAO_TEXT, SAO_START_NUMBER, PAO_TEXT, PAO_START_NUMBER and STREET_DESCRIPTION.

--- a/src/KeeperData.Core/Domain/Shared/Address.cs
+++ b/src/KeeperData.Core/Domain/Shared/Address.cs
@@ -5,7 +5,7 @@ namespace KeeperData.Core.Domain.Shared;
 public class Address : EntityObject
 {
     public string Id { get; private set; }
-    public int? Uprn { get; private set; }
+    public string? Uprn { get; private set; }
     public string AddressLine1 { get; private set; }
     public string? AddressLine2 { get; private set; }
     public string? PostTown { get; private set; }
@@ -16,7 +16,7 @@ public class Address : EntityObject
 
     public Address(
         string id,
-        int? uprn,
+        string? uprn,
         string addressLine1,
         string? addressLine2,
         string? postTown,
@@ -37,7 +37,7 @@ public class Address : EntityObject
     }
 
     public static Address Create(
-        int? uprn,
+        string? uprn,
         string addressLine1,
         string? addressLine2,
         string? postTown,
@@ -59,7 +59,7 @@ public class Address : EntityObject
 
     public bool ApplyChanges(
         DateTime lastUpdatedDate,
-        int? uprn,
+        string? uprn,
         string addressLine1,
         string? addressLine2,
         string? postTown,
@@ -90,7 +90,7 @@ public class Address : EntityObject
 
     public override IEnumerable<object> GetEqualityComponents()
     {
-        yield return Uprn ?? 0;
+        yield return Uprn ?? string.Empty;
         yield return AddressLine1;
         yield return AddressLine2 ?? string.Empty;
         yield return PostTown ?? string.Empty;

--- a/src/KeeperData.Core/Serialization/UprnSerializer.cs
+++ b/src/KeeperData.Core/Serialization/UprnSerializer.cs
@@ -9,7 +9,6 @@ public class UprnSerializer : SerializerBase<string?>
     public override string? Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
     {
         var bsonType = context.Reader.GetCurrentBsonType();
-        
         switch (bsonType)
         {
             case BsonType.Null:

--- a/src/KeeperData.Core/Serialization/UprnSerializer.cs
+++ b/src/KeeperData.Core/Serialization/UprnSerializer.cs
@@ -1,0 +1,42 @@
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+
+namespace KeeperData.Core.Serialization;
+
+public class UprnSerializer : SerializerBase<string?>
+{
+    public override string? Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+    {
+        var bsonType = context.Reader.GetCurrentBsonType();
+        
+        switch (bsonType)
+        {
+            case BsonType.Null:
+                context.Reader.ReadNull();
+                return null;
+            case BsonType.String:
+                return context.Reader.ReadString();
+            case BsonType.Int32:
+                return context.Reader.ReadInt32().ToString();
+            case BsonType.Int64:
+                return context.Reader.ReadInt64().ToString();
+            case BsonType.Double:
+                return context.Reader.ReadDouble().ToString("F0");
+            default:
+                throw new BsonSerializationException($"Cannot deserialize UPRN from BsonType {bsonType}");
+        }
+    }
+
+    public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, string? value)
+    {
+        if (value is null)
+        {
+            context.Writer.WriteNull();
+        }
+        else
+        {
+            context.Writer.WriteString(value);
+        }
+    }
+}

--- a/tests/KeeperData.Application.Tests.Unit/Orchestration/Imports/Sam/Mappings/SamPartyMapperToGoldTests.cs
+++ b/tests/KeeperData.Application.Tests.Unit/Orchestration/Imports/Sam/Mappings/SamPartyMapperToGoldTests.cs
@@ -107,7 +107,7 @@ public class SamPartyMapperToGoldTests
                     expected.CorrespondanceAddress!.County = "locale";
                     expected.CorrespondanceAddress!.Postcode = "postcode";
                     expected.CorrespondanceAddress!.PostTown = "town";
-                    expected.CorrespondanceAddress!.Uprn = 1234;
+                    expected.CorrespondanceAddress!.Uprn = "1234";
                 }];
             yield return [ "When mapping empty PartyDocument.Communication",
                 (SamPartyDocument input) =>

--- a/tests/KeeperData.Core.Tests.Unit/Documents/SiteDocumentExtensionsTests.cs
+++ b/tests/KeeperData.Core.Tests.Unit/Documents/SiteDocumentExtensionsTests.cs
@@ -282,7 +282,7 @@ public class SiteDocumentExtensionsTests
         var addressDocument = new AddressDocument
         {
             IdentifierId = "addr-1",
-            Uprn = 10002345,
+            Uprn = "10002345",
             AddressLine1 = "10 Downing Street",
             AddressLine2 = "Westminster",
             PostTown = "London",
@@ -322,7 +322,7 @@ public class SiteDocumentExtensionsTests
         // Assert
         result.Location!.Address.Should().NotBeNull();
         var address = result.Location.Address!;
-        address.Uprn.Should().Be(10002345);
+        address.Uprn.Should().Be("10002345");
         address.AddressLine1.Should().Be("10 Downing Street");
         address.Postcode.Should().Be("SW1A 2AA");
         address.Country.Should().NotBeNull();

--- a/tests/KeeperData.Core.Tests.Unit/Domain/Sites/EqualityTestAddressHelper.cs
+++ b/tests/KeeperData.Core.Tests.Unit/Domain/Sites/EqualityTestAddressHelper.cs
@@ -5,7 +5,7 @@ namespace KeeperData.Core.Tests.Unit.Domain.Sites;
 public static class EqualityTestAddressHelper
 {
 
-    public static Address AddressWith(string id, int? propertyRef = null, string line1 = "", string? line2 = null, string? postTown = "", string? county = null, string postcode = "", Country? country = null, DateTime? updated = null)
+    public static Address AddressWith(string id, string? propertyRef = null, string line1 = "", string? line2 = null, string? postTown = "", string? county = null, string postcode = "", Country? country = null, DateTime? updated = null)
     {
         return new Address(id, propertyRef, line1, line2, postTown, county, postcode, country, updated ?? DateTime.MinValue);
     }

--- a/tests/KeeperData.Core.Tests.Unit/Serialization/UprnSerializerTests.cs
+++ b/tests/KeeperData.Core.Tests.Unit/Serialization/UprnSerializerTests.cs
@@ -1,0 +1,224 @@
+using FluentAssertions;
+using KeeperData.Core.Serialization;
+using MongoDB.Bson;
+using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization;
+
+namespace KeeperData.Core.Tests.Unit.Serialization;
+
+public class UprnSerializerTests
+{
+    private readonly UprnSerializer _sut = new();
+
+    [Fact]
+    public void Serialize_WithNullValue_WritesNull()
+    {
+        var document = new BsonDocument();
+        using var writer = new BsonDocumentWriter(document);
+        var context = BsonSerializationContext.CreateRoot(writer);
+
+        writer.WriteStartDocument();
+        writer.WriteName("uprn");
+        _sut.Serialize(context, new BsonSerializationArgs(), null);
+        writer.WriteEndDocument();
+
+        document["uprn"].BsonType.Should().Be(BsonType.Null);
+    }
+
+    [Fact]
+    public void Serialize_WithStringValue_WritesString()
+    {
+        var document = new BsonDocument();
+        using var writer = new BsonDocumentWriter(document);
+        var context = BsonSerializationContext.CreateRoot(writer);
+
+        writer.WriteStartDocument();
+        writer.WriteName("uprn");
+        _sut.Serialize(context, new BsonSerializationArgs(), "123456789");
+        writer.WriteEndDocument();
+
+        document["uprn"].BsonType.Should().Be(BsonType.String);
+        document["uprn"].AsString.Should().Be("123456789");
+    }
+
+    [Fact]
+    public void Deserialize_WithNullBsonType_ReturnsNull()
+    {
+        var document = new BsonDocument { { "uprn", BsonNull.Value } };
+        using var reader = new BsonDocumentReader(document);
+        var context = BsonDeserializationContext.CreateRoot(reader);
+
+        reader.ReadStartDocument();
+        reader.ReadName();
+        var result = _sut.Deserialize(context, new BsonDeserializationArgs());
+        reader.ReadEndDocument();
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void Deserialize_WithStringBsonType_ReturnsString()
+    {
+        var document = new BsonDocument { { "uprn", "987654321" } };
+        using var reader = new BsonDocumentReader(document);
+        var context = BsonDeserializationContext.CreateRoot(reader);
+
+        reader.ReadStartDocument();
+        reader.ReadName();
+        var result = _sut.Deserialize(context, new BsonDeserializationArgs());
+        reader.ReadEndDocument();
+
+        result.Should().Be("987654321");
+    }
+
+    [Fact]
+    public void Deserialize_WithInt32BsonType_ConvertsToString()
+    {
+        var document = new BsonDocument { { "uprn", 25962203 } };
+        using var reader = new BsonDocumentReader(document);
+        var context = BsonDeserializationContext.CreateRoot(reader);
+
+        reader.ReadStartDocument();
+        reader.ReadName();
+        var result = _sut.Deserialize(context, new BsonDeserializationArgs());
+        reader.ReadEndDocument();
+
+        result.Should().Be("25962203");
+    }
+
+    [Fact]
+    public void Deserialize_WithInt64BsonType_ConvertsToString()
+    {
+        var document = new BsonDocument { { "uprn", 9876543210123L } };
+        using var reader = new BsonDocumentReader(document);
+        var context = BsonDeserializationContext.CreateRoot(reader);
+
+        reader.ReadStartDocument();
+        reader.ReadName();
+        var result = _sut.Deserialize(context, new BsonDeserializationArgs());
+        reader.ReadEndDocument();
+
+        result.Should().Be("9876543210123");
+    }
+
+    [Fact]
+    public void Deserialize_WithDoubleBsonType_ConvertsToStringWithoutDecimals()
+    {
+        var document = new BsonDocument { { "uprn", 123456.789 } };
+        using var reader = new BsonDocumentReader(document);
+        var context = BsonDeserializationContext.CreateRoot(reader);
+
+        reader.ReadStartDocument();
+        reader.ReadName();
+        var result = _sut.Deserialize(context, new BsonDeserializationArgs());
+        reader.ReadEndDocument();
+
+        result.Should().Be("123457");
+    }
+
+    [Fact]
+    public void Deserialize_WithUnsupportedBsonType_ThrowsBsonSerializationException()
+    {
+        var document = new BsonDocument { { "uprn", new BsonArray { 1, 2, 3 } } };
+        using var reader = new BsonDocumentReader(document);
+        var context = BsonDeserializationContext.CreateRoot(reader);
+
+        reader.ReadStartDocument();
+        reader.ReadName();
+        
+        var act = () => _sut.Deserialize(context, new BsonDeserializationArgs());
+
+        act.Should().Throw<BsonSerializationException>()
+            .WithMessage("Cannot deserialize UPRN from BsonType Array");
+    }
+
+    [Theory]
+    [InlineData(0, "0")]
+    [InlineData(123, "123")]
+    [InlineData(25962203, "25962203")]
+    [InlineData(-1, "-1")]
+    public void Deserialize_WithVariousInt32Values_ConvertsCorrectly(int input, string expected)
+    {
+        var document = new BsonDocument { { "uprn", input } };
+        using var reader = new BsonDocumentReader(document);
+        var context = BsonDeserializationContext.CreateRoot(reader);
+
+        reader.ReadStartDocument();
+        reader.ReadName();
+        var result = _sut.Deserialize(context, new BsonDeserializationArgs());
+        reader.ReadEndDocument();
+
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("", "")]
+    [InlineData("ABC123", "ABC123")]
+    [InlineData("  123  ", "  123  ")]
+    public void Serialize_Deserialize_RoundTrip_WithStringValues(string input, string expected)
+    {
+        var document = new BsonDocument();
+        using var writer = new BsonDocumentWriter(document);
+        var writeContext = BsonSerializationContext.CreateRoot(writer);
+
+        writer.WriteStartDocument();
+        writer.WriteName("uprn");
+        _sut.Serialize(writeContext, new BsonSerializationArgs(), input);
+        writer.WriteEndDocument();
+
+        using var reader = new BsonDocumentReader(document);
+        var readContext = BsonDeserializationContext.CreateRoot(reader);
+
+        reader.ReadStartDocument();
+        reader.ReadName();
+        var result = _sut.Deserialize(readContext, new BsonDeserializationArgs());
+        reader.ReadEndDocument();
+
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void Deserialize_WithMaxInt32Value_ConvertsToString()
+    {
+        var document = new BsonDocument { { "uprn", int.MaxValue } };
+        using var reader = new BsonDocumentReader(document);
+        var context = BsonDeserializationContext.CreateRoot(reader);
+
+        reader.ReadStartDocument();
+        reader.ReadName();
+        var result = _sut.Deserialize(context, new BsonDeserializationArgs());
+        reader.ReadEndDocument();
+
+        result.Should().Be(int.MaxValue.ToString());
+    }
+
+    [Fact]
+    public void Deserialize_WithMaxInt64Value_ConvertsToString()
+    {
+        var document = new BsonDocument { { "uprn", long.MaxValue } };
+        using var reader = new BsonDocumentReader(document);
+        var context = BsonDeserializationContext.CreateRoot(reader);
+
+        reader.ReadStartDocument();
+        reader.ReadName();
+        var result = _sut.Deserialize(context, new BsonDeserializationArgs());
+        reader.ReadEndDocument();
+
+        result.Should().Be(long.MaxValue.ToString());
+    }
+
+    [Fact]
+    public void Deserialize_WithDouble_RemovesDecimalPoints()
+    {
+        var document = new BsonDocument { { "uprn", 25962203.0 } };
+        using var reader = new BsonDocumentReader(document);
+        var context = BsonDeserializationContext.CreateRoot(reader);
+
+        reader.ReadStartDocument();
+        reader.ReadName();
+        var result = _sut.Deserialize(context, new BsonDeserializationArgs());
+        reader.ReadEndDocument();
+
+        result.Should().Be("25962203");
+    }
+}

--- a/tests/KeeperData.Core.Tests.Unit/Serialization/UprnSerializerTests.cs
+++ b/tests/KeeperData.Core.Tests.Unit/Serialization/UprnSerializerTests.cs
@@ -125,7 +125,6 @@ public class UprnSerializerTests
 
         reader.ReadStartDocument();
         reader.ReadName();
-        
         var act = () => _sut.Deserialize(context, new BsonDeserializationArgs());
 
         act.Should().Throw<BsonSerializationException>()

--- a/tests/KeeperData.Tests.Common/TestData/Sam/ExpectedOutcomes/ExpectedGoldParties.cs
+++ b/tests/KeeperData.Tests.Common/TestData/Sam/ExpectedOutcomes/ExpectedGoldParties.cs
@@ -41,7 +41,7 @@ public static class ExpectedGoldParties
                 CorrespondanceAddress = new AddressDocument
                 {
                     IdentifierId = Guid.NewGuid().ToString(),
-                    Uprn = 25962203,
+                    Uprn = "25962203",
                     AddressLine1 = "1-3, 10-12",
                     AddressLine2 = "Elm Grove",
                     PostTown = "Manchester",
@@ -278,7 +278,7 @@ public static class ExpectedGoldParties
                 CorrespondanceAddress = new AddressDocument
                 {
                     IdentifierId = Guid.NewGuid().ToString(),
-                    Uprn = 25962203,
+                    Uprn = "25962203",
                     AddressLine1 = "1-3, 10-12",
                     AddressLine2 = "Elm Grove",
                     PostTown = "Manchester",
@@ -400,7 +400,7 @@ public static class ExpectedGoldParties
                 CorrespondanceAddress = new AddressDocument
                 {
                     IdentifierId = Guid.NewGuid().ToString(),
-                    Uprn = 25962203,
+                    Uprn = "25962203",
                     AddressLine1 = "1-3, 10-12",
                     AddressLine2 = "Elm Grove",
                     PostTown = "Manchester",
@@ -509,7 +509,7 @@ public static class ExpectedGoldParties
                 CorrespondanceAddress = new AddressDocument
                 {
                     IdentifierId = Guid.NewGuid().ToString(),
-                    Uprn = 25962203,
+                    Uprn = "25962203",
                     AddressLine1 = "1-3, 10-12",
                     AddressLine2 = "Elm Grove",
                     PostTown = "Manchester",

--- a/tests/KeeperData.Tests.Common/TestData/Sam/ExpectedOutcomes/ExpectedGoldSite.cs
+++ b/tests/KeeperData.Tests.Common/TestData/Sam/ExpectedOutcomes/ExpectedGoldSite.cs
@@ -42,7 +42,7 @@ public static class ExpectedGoldSite
                 Address = new AddressDocument()
                 {
                     IdentifierId = Guid.NewGuid().ToString(),
-                    Uprn = 25962203,
+                    Uprn = "25962203",
                     AddressLine1 = "1-3, 10-12",
                     AddressLine2 = "Market Square",
                     PostTown = "Oxford",
@@ -115,7 +115,7 @@ public static class ExpectedGoldSite
                     CorrespondanceAddress = new AddressDocument
                     {
                         IdentifierId = Guid.NewGuid().ToString(),
-                        Uprn = 25962203,
+                        Uprn = "25962203",
                         AddressLine1 = "1-3, 10-12",
                         AddressLine2 = "Elm Grove",
                         PostTown = "Manchester",
@@ -255,7 +255,7 @@ public static class ExpectedGoldSite
                     CorrespondanceAddress = new AddressDocument
                     {
                         IdentifierId = Guid.NewGuid().ToString(),
-                        Uprn = 25962203,
+                        Uprn = "25962203",
                         AddressLine1 = "1-3, 10-12",
                         AddressLine2 = "Elm Grove",
                         PostTown = "Manchester",
@@ -469,7 +469,7 @@ public static class ExpectedGoldSite
                     CorrespondanceAddress = new AddressDocument
                     {
                         IdentifierId = Guid.NewGuid().ToString(),
-                        Uprn = 25962203,
+                        Uprn = "25962203",
                         AddressLine1 = "1-3, 10-12",
                         AddressLine2 = "Elm Grove",
                         PostTown = "Manchester",
@@ -545,7 +545,7 @@ public static class ExpectedGoldSite
                     CorrespondanceAddress = new AddressDocument
                     {
                         IdentifierId = Guid.NewGuid().ToString(),
-                        Uprn = 25962203,
+                        Uprn = "25962203",
                         AddressLine1 = "1-3, 10-12",
                         AddressLine2 = "Elm Grove",
                         PostTown = "Manchester",


### PR DESCRIPTION
- Change UPRN properties from int? to string? in Address, AddressDto, and AddressDocument
- Add UprnSerializer for robust MongoDB BSON <-> string conversion
- Update all mapping, equality, and test logic to use string UPRNs
- Add unit tests for UprnSerializer covering all BSON types
- Ensures UPRNs with leading zeros or large values are handled safely