### PR TITLE
Set default values for SiteIdentifierTypeDto string properties

### DIFF
--- a/src/KeeperData.Core/DTOs/SiteIdentifierDto.cs
+++ b/src/KeeperData.Core/DTOs/SiteIdentifierDto.cs
@@ -36,7 +36,7 @@ public class SiteIdentifierDto
 /// <summary>
 /// The type which identifies the site identifier.
 /// </summary>
-public class SiteIdentifierTypeDto: ISummaryDto
+public class SiteIdentifierTypeDto : ISummaryDto
 {
     /// <summary>
     /// This is an immutable field which represents the golden key of the reference object.

--- a/src/KeeperData.Core/DTOs/SiteIdentifierDto.cs
+++ b/src/KeeperData.Core/DTOs/SiteIdentifierDto.cs
@@ -42,21 +42,21 @@ public class SiteIdentifierTypeDto: ISummaryDto
     /// This is an immutable field which represents the golden key of the reference object.
     /// </summary>
     [JsonPropertyName("id")]
-    public string IdentifierId { get; set; }
+    public string IdentifierId { get; set; } = string.Empty;
 
     /// <summary>
     /// The business key/code values for a Site Identifier Type.
     /// </summary>
     /// <example>CPHN</example>
     [JsonPropertyName("code")]
-    public string Code { get; set; }
+    public string Code { get; set; } = string.Empty;
 
     /// <summary>
     /// The type which identifies the site identifier.
     /// </summary>
     /// <example>CPH Number</example>
     [JsonPropertyName("name")]
-    public string Name { get; set; }
+    public string Name { get; set; } = string.Empty;
 
     /// <summary>
     /// The timestamp of the last time the SiteIdentifier Type record was updated.

--- a/src/KeeperData.Core/DTOs/SiteTypeSummaryDto.cs
+++ b/src/KeeperData.Core/DTOs/SiteTypeSummaryDto.cs
@@ -5,7 +5,7 @@ namespace KeeperData.Core.DTOs;
 /// <summary>
 /// The type of site an animal may reside at.
 /// </summary>
-public class SiteTypeSummaryDto: ISummaryDto
+public class SiteTypeSummaryDto : ISummaryDto
 {
     /// <summary>
     /// This is an immutable field which represents the golden key of the reference object.

--- a/src/KeeperData.Core/Documents/SiteIdentifierSummaryDocument.cs
+++ b/src/KeeperData.Core/Documents/SiteIdentifierSummaryDocument.cs
@@ -8,7 +8,7 @@ namespace KeeperData.Core.Documents;
 /// <summary>
 /// The type which identifies the site identifier.
 /// </summary>
-public class SiteIdentifierSummaryDocument: ISummaryDocument
+public class SiteIdentifierSummaryDocument : ISummaryDocument
 {
     /// <summary>
     /// This is an immutable field which represents the golden key of the reference object.


### PR DESCRIPTION
Updated IdentifierId, Code, and Name properties in SiteIdentifierTypeDto to default to string.Empty, ensuring they are never null and improving null safety.