### PR TITLE
Add PermanentLandHoldingIdentifier to Site models

### DIFF
--- a/src/KeeperData.Application/Orchestration/Imports/Sam/Mappings/SamHoldingMapper.cs
+++ b/src/KeeperData.Application/Orchestration/Imports/Sam/Mappings/SamHoldingMapper.cs
@@ -343,10 +343,11 @@ public static class SamHoldingMapper
             SourceSystemType.SAM.ToString(),
             null,
             representative.Deleted,
-            representative.SecondaryCph,
+            representative.CphRelationshipType.IsPermanentLandHolding() ? null : representative.SecondaryCph,
             representative.CphTypeIdentifier,
             siteType,
-            location);
+            location,
+            representative.CphRelationshipType.IsPermanentLandHolding() ? representative.SecondaryCph : null);
 
         if (siteIdentifierType != null)
         {
@@ -396,8 +397,9 @@ public static class SamHoldingMapper
             SourceSystemType.SAM.ToString(),
             null,
             representative.Deleted,
-            representative.SecondaryCph,
-            representative.CphTypeIdentifier);
+            representative.CphRelationshipType.IsPermanentLandHolding() ? null : representative.SecondaryCph,
+            representative.CphTypeIdentifier,
+            representative.CphRelationshipType.IsPermanentLandHolding() ? representative.SecondaryCph : null);
 
         var updatedAddress = await LocationMapper.AddressToGold(representative.Location?.Address, getCountryById, cancellationToken);
         var updatedCommunication = LocationMapper.CommunicationToGold(representative.Communication);

--- a/src/KeeperData.Core/DTOs/SiteDto.cs
+++ b/src/KeeperData.Core/DTOs/SiteDto.cs
@@ -104,4 +104,7 @@ public class SiteDto
 
     [JsonPropertyName("holdingType")]
     public string? HoldingType { get; set; }
+
+    [JsonPropertyName("permanentLandHoldingIdentifier")]
+    public string? PermanentLandHoldingIdentifier { get; set; }
 }

--- a/src/KeeperData.Core/Documents/SiteDocument.cs
+++ b/src/KeeperData.Core/Documents/SiteDocument.cs
@@ -88,6 +88,10 @@ public class SiteDocument : IEntity, IDeletableEntity, IContainsIndexes
     [JsonPropertyName("holdingType")]
     public string? HoldingType { get; set; }
 
+    [BsonElement("permanentLandHoldingIdentifier")]
+    [JsonPropertyName("permanentLandHoldingIdentifier")]
+    public string? PermanentLandHoldingIdentifier { get; set; }
+
     /// <summary>
     /// Indicates whether identity documents should be destroyed for this site.
     /// </summary>
@@ -163,7 +167,8 @@ public class SiteDocument : IEntity, IDeletableEntity, IContainsIndexes
         Marks = [.. m.Marks.Select(GroupMarkDocument.FromDomain)],
         Activities = [.. m.Activities.Select(SiteActivityDocument.FromDomain)],
         ParentSiteIdentifier = m.ParentSiteIdentifier,
-        HoldingType = m.HoldingType
+        HoldingType = m.HoldingType,
+        PermanentLandHoldingIdentifier = m.PermanentLandHoldingIdentifier
     };
 
     public Site ToDomain()
@@ -182,7 +187,8 @@ public class SiteDocument : IEntity, IDeletableEntity, IContainsIndexes
             Type?.ToDomain(),
             Location?.ToDomain(),
             ParentSiteIdentifier,
-            HoldingType
+            HoldingType,
+            PermanentLandHoldingIdentifier
         );
 
         foreach (var si in Identifiers)

--- a/src/KeeperData.Core/Documents/SiteDocumentExtensions.cs
+++ b/src/KeeperData.Core/Documents/SiteDocumentExtensions.cs
@@ -28,7 +28,8 @@ public static class SiteDocumentExtensions
         Marks = doc.Marks?.Select(m => m.ToDto()).ToList() ?? [],
         Activities = doc.Activities?.Select(a => a.ToDto()).ToList() ?? [],
         ParentSiteIdentifier = doc.ParentSiteIdentifier,
-        HoldingType = doc.HoldingType
+        HoldingType = doc.HoldingType,
+        PermanentLandHoldingIdentifier = doc.PermanentLandHoldingIdentifier
     };
 
     private static SiteTypeSummaryDto ToDto(this SiteTypeSummaryDocument doc) => new()

--- a/src/KeeperData.Core/Domain/Sites/Site.cs
+++ b/src/KeeperData.Core/Domain/Sites/Site.cs
@@ -21,6 +21,7 @@ public class Site : IAggregateRoot
 
     public string? ParentSiteIdentifier { get; private set; }
     public string? HoldingType { get; private set; }
+    public string? PermanentLandHoldingIdentifier { get; private set; }
 
     private readonly List<SiteIdentifier> _identifiers = [];
     public IReadOnlyCollection<SiteIdentifier> Identifiers => _identifiers.AsReadOnly();
@@ -58,7 +59,8 @@ public class Site : IAggregateRoot
         SiteType? type,
         Location? location,
         string? parentSiteIdentifier,
-        string? holdingType)
+        string? holdingType,
+        string? permanentLandHoldingIdentifier)
     {
         Id = id;
         CreatedDate = createdDate;
@@ -74,6 +76,7 @@ public class Site : IAggregateRoot
         _location = location;
         ParentSiteIdentifier = parentSiteIdentifier;
         HoldingType = holdingType;
+        PermanentLandHoldingIdentifier = permanentLandHoldingIdentifier;
     }
 
     public static Site Create(
@@ -90,7 +93,8 @@ public class Site : IAggregateRoot
         string? parentSiteIdentifier,
         string? holdingType,
         SiteType? type = null,
-        Location? location = null)
+        Location? location = null,
+        string? permanentLandHoldingIdentifier = null)
     {
         var site = new Site(
             id,
@@ -106,7 +110,8 @@ public class Site : IAggregateRoot
             type,
             location,
             parentSiteIdentifier,
-            holdingType);
+            holdingType,
+            permanentLandHoldingIdentifier);
 
         site._domainEvents.Add(new SiteCreatedDomainEvent(site.Id));
         return site;
@@ -122,7 +127,8 @@ public class Site : IAggregateRoot
         bool? destroyIdentityDocumentsFlag,
         bool deleted,
         string? parentSiteIdentifier,
-        string? holdingType)
+        string? holdingType,
+        string? permanentLandHoldingIdentifier)
     {
         var changed = false;
 
@@ -135,6 +141,7 @@ public class Site : IAggregateRoot
         changed |= Change(Deleted, deleted, v => Deleted = v, lastUpdatedDate);
         changed |= Change(ParentSiteIdentifier, parentSiteIdentifier, v => ParentSiteIdentifier = v, lastUpdatedDate);
         changed |= Change(HoldingType, holdingType, v => HoldingType = v, lastUpdatedDate);
+        changed |= Change(PermanentLandHoldingIdentifier, permanentLandHoldingIdentifier, v => PermanentLandHoldingIdentifier = v, lastUpdatedDate);
 
         if (changed)
         {

--- a/src/KeeperData.Core/Extensions/StringExtensions.cs
+++ b/src/KeeperData.Core/Extensions/StringExtensions.cs
@@ -1,0 +1,11 @@
+namespace KeeperData.Core.Extensions;
+
+public static class StringExtensions
+{
+    private const string PermanentLandHoldingRelationshipType = "PCPHLANDUSEDBYTCPH";
+
+    public static bool IsPermanentLandHolding(this string? cphRelationshipType)
+    {
+        return string.Equals(cphRelationshipType, PermanentLandHoldingRelationshipType, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/KeeperData.Application.Tests.Unit/Orchestration/Imports/Sam/Mappings/SamHoldingMapperTests.cs
+++ b/tests/KeeperData.Application.Tests.Unit/Orchestration/Imports/Sam/Mappings/SamHoldingMapperTests.cs
@@ -2,6 +2,8 @@ using FluentAssertions;
 using KeeperData.Application.Orchestration.Imports.Sam.Mappings;
 using KeeperData.Core.ApiClients.DataBridgeApi;
 using KeeperData.Core.ApiClients.DataBridgeApi.Contracts;
+using KeeperData.Core.Documents;
+using KeeperData.Core.Documents.Silver;
 using KeeperData.Core.Services;
 using KeeperData.Tests.Common.Factories;
 using KeeperData.Tests.Common.Generators;
@@ -94,7 +96,134 @@ public class SamHoldingMapperTests
         }
     }
 
-    // TODO - ADD ToGold Tests
+    [Fact]
+    public async Task ToGold_WithPermanentLandHoldingRelationship_ShouldSetPermanentLandHoldingIdentifier()
+    {
+        var silverHolding = new SamHoldingDocument
+        {
+            CountyParishHoldingNumber = "12/345/6789",
+            SecondaryCph = "12/345/9999",
+            CphRelationshipType = "PCPHLANDUSEDBYTCPH",
+            LocationName = "Test Farm",
+            CphTypeIdentifier = "PERMANENT",
+            CreatedDate = DateTime.UtcNow,
+            LastUpdatedDate = DateTime.UtcNow,
+            HoldingStartDate = DateTime.UtcNow
+        };
+
+        var siteIdentifierType = new SiteIdentifierTypeDocument
+        {
+            IdentifierId = "type-id",
+            Code = "CPHN",
+            Name = "CPH Number",
+            LastModifiedDate = DateTime.UtcNow
+        };
+
+        var result = await SamHoldingMapper.ToGold(
+            "gold-site-id",
+            null,
+            [silverHolding],
+            [],
+            [],
+            (_, _) => Task.FromResult<CountryDocument?>(null),
+            (_, _) => Task.FromResult<SiteTypeDocument?>(null),
+            (code, _) => Task.FromResult<SiteIdentifierTypeDocument?>(
+                code == "CPHN" ? siteIdentifierType : null),
+            (_, _) => Task.FromResult<(string?, string?)>((null, null)),
+            (_, _) => Task.FromResult<SiteActivityTypeDocument?>(null),
+            Mock.Of<ISiteTypeDerivedCodeLookupService>(),
+            CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.ParentSiteIdentifier.Should().BeNull();
+        result.PermanentLandHoldingIdentifier.Should().Be("12/345/9999");
+    }
+
+    [Fact]
+    public async Task ToGold_WithNonPermanentLandHoldingRelationship_ShouldSetParentSiteIdentifier()
+    {
+        var silverHolding = new SamHoldingDocument
+        {
+            CountyParishHoldingNumber = "12/345/6789",
+            SecondaryCph = "12/345/8888",
+            CphRelationshipType = "OTHERTYPECPH",
+            LocationName = "Test Farm",
+            CphTypeIdentifier = "PERMANENT",
+            CreatedDate = DateTime.UtcNow,
+            LastUpdatedDate = DateTime.UtcNow,
+            HoldingStartDate = DateTime.UtcNow
+        };
+
+        var siteIdentifierType = new SiteIdentifierTypeDocument
+        {
+            IdentifierId = "type-id",
+            Code = "CPHN",
+            Name = "CPH Number",
+            LastModifiedDate = DateTime.UtcNow
+        };
+
+        var result = await SamHoldingMapper.ToGold(
+            "gold-site-id",
+            null,
+            [silverHolding],
+            [],
+            [],
+            (_, _) => Task.FromResult<CountryDocument?>(null),
+            (_, _) => Task.FromResult<SiteTypeDocument?>(null),
+            (code, _) => Task.FromResult<SiteIdentifierTypeDocument?>(
+                code == "CPHN" ? siteIdentifierType : null),
+            (_, _) => Task.FromResult<(string?, string?)>((null, null)),
+            (_, _) => Task.FromResult<SiteActivityTypeDocument?>(null),
+            Mock.Of<ISiteTypeDerivedCodeLookupService>(),
+            CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.ParentSiteIdentifier.Should().Be("12/345/8888");
+        result.PermanentLandHoldingIdentifier.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ToGold_WithNullSecondaryCph_ShouldHaveNullIdentifiers()
+    {
+        var silverHolding = new SamHoldingDocument
+        {
+            CountyParishHoldingNumber = "12/345/6789",
+            SecondaryCph = null,
+            CphRelationshipType = null,
+            LocationName = "Test Farm",
+            CphTypeIdentifier = "PERMANENT",
+            CreatedDate = DateTime.UtcNow,
+            LastUpdatedDate = DateTime.UtcNow,
+            HoldingStartDate = DateTime.UtcNow
+        };
+
+        var siteIdentifierType = new SiteIdentifierTypeDocument
+        {
+            IdentifierId = "type-id",
+            Code = "CPHN",
+            Name = "CPH Number",
+            LastModifiedDate = DateTime.UtcNow
+        };
+
+        var result = await SamHoldingMapper.ToGold(
+            "gold-site-id",
+            null,
+            [silverHolding],
+            [],
+            [],
+            (_, _) => Task.FromResult<CountryDocument?>(null),
+            (_, _) => Task.FromResult<SiteTypeDocument?>(null),
+            (code, _) => Task.FromResult<SiteIdentifierTypeDocument?>(
+                code == "CPHN" ? siteIdentifierType : null),
+            (_, _) => Task.FromResult<(string?, string?)>((null, null)),
+            (_, _) => Task.FromResult<SiteActivityTypeDocument?>(null),
+            Mock.Of<ISiteTypeDerivedCodeLookupService>(),
+            CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.ParentSiteIdentifier.Should().BeNull();
+        result.PermanentLandHoldingIdentifier.Should().BeNull();
+    }
 
     private static List<SamCphHolding> GenerateSamCphHolding(int quantity)
     {

--- a/tests/KeeperData.Core.Tests.Unit/Documents/SiteDocumentExtensionsTests.cs
+++ b/tests/KeeperData.Core.Tests.Unit/Documents/SiteDocumentExtensionsTests.cs
@@ -739,6 +739,52 @@ public class SiteDocumentExtensionsTests
         species.EndDate.Should().Be(new DateTime(2024, 12, 31));
     }
 
+    [Fact]
+    public void ToDto_WithPermanentLandHoldingIdentifier_ShouldMapCorrectly()
+    {
+        // Arrange
+        var siteDocument = new SiteDocument
+        {
+            Id = "site-123",
+            Name = "Test Site",
+            StartDate = DateTime.UtcNow,
+            LastUpdatedDate = DateTime.UtcNow,
+            ParentSiteIdentifier = "PARENT-456",
+            HoldingType = "PERMANENT",
+            PermanentLandHoldingIdentifier = "12/345/9999",
+            Identifiers = []
+        };
+
+        // Act
+        var result = siteDocument.ToDto();
+
+        // Assert
+        result.ParentSiteIdentifier.Should().Be("PARENT-456");
+        result.HoldingType.Should().Be("PERMANENT");
+        result.PermanentLandHoldingIdentifier.Should().Be("12/345/9999");
+    }
+
+    [Fact]
+    public void ToDto_WithNullPermanentLandHoldingIdentifier_ShouldMapAsNull()
+    {
+        // Arrange
+        var siteDocument = new SiteDocument
+        {
+            Id = "site-123",
+            Name = "Test Site",
+            StartDate = DateTime.UtcNow,
+            LastUpdatedDate = DateTime.UtcNow,
+            PermanentLandHoldingIdentifier = null,
+            Identifiers = []
+        };
+
+        // Act
+        var result = siteDocument.ToDto();
+
+        // Assert
+        result.PermanentLandHoldingIdentifier.Should().BeNull();
+    }
+
     private static SiteDocument CreateFullSiteDocument()
     {
         return new SiteDocument

--- a/tests/KeeperData.Core.Tests.Unit/Domain/Sites/SiteDocumentTests.cs
+++ b/tests/KeeperData.Core.Tests.Unit/Domain/Sites/SiteDocumentTests.cs
@@ -10,7 +10,7 @@ public class SiteDocumentTests
     public void WhenSiteIsEmpty_ToDomainShouldMapCorrectly()
     {
         var sut = new SiteDocument() { Id = "", Name = "" };
-        var expected = new Site("", DateTime.MinValue, DateTime.MinValue, "", DateTime.MinValue, null, null, null, null, false, null, null, null, null);
+        var expected = new Site("", DateTime.MinValue, DateTime.MinValue, "", DateTime.MinValue, null, null, null, null, false, null, null, null, null, null);
 
         var result = sut.ToDomain();
 
@@ -47,6 +47,92 @@ public class SiteDocumentTests
         result.Activities.Select(x => x.Id).Should().BeEquivalentTo(["act-1-id", "act-2-id", "act-3-id"]);
     }
 
+    [Fact]
+    public void FromDomain_WithPermanentLandHoldingIdentifier_ShouldMapCorrectly()
+    {
+        var permanentLandHoldingId = "12/345/9999";
+        var site = Site.Create(
+            "site-id",
+            DateTime.UtcNow,
+            DateTime.UtcNow,
+            "Test Site",
+            DateTime.UtcNow,
+            null,
+            null,
+            "SAM",
+            null,
+            false,
+            null,
+            "PERMANENT",
+            null,
+            null,
+            permanentLandHoldingId);
+
+        var result = SiteDocument.FromDomain(site);
+
+        result.PermanentLandHoldingIdentifier.Should().Be(permanentLandHoldingId);
+    }
+
+    [Fact]
+    public void FromDomain_WithNullPermanentLandHoldingIdentifier_ShouldBeNull()
+    {
+        var site = Site.Create(
+            "site-id",
+            DateTime.UtcNow,
+            DateTime.UtcNow,
+            "Test Site",
+            DateTime.UtcNow,
+            null,
+            null,
+            "SAM",
+            null,
+            false,
+            null,
+            "PERMANENT",
+            null,
+            null,
+            null);
+
+        var result = SiteDocument.FromDomain(site);
+
+        result.PermanentLandHoldingIdentifier.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToDomain_WithPermanentLandHoldingIdentifier_ShouldMapCorrectly()
+    {
+        var permanentLandHoldingId = "12/345/9999";
+        var siteDocument = new SiteDocument
+        {
+            Id = "site-id",
+            Name = "Test Site",
+            StartDate = DateTime.UtcNow,
+            LastUpdatedDate = DateTime.UtcNow,
+            PermanentLandHoldingIdentifier = permanentLandHoldingId
+        };
+
+        var result = siteDocument.ToDomain();
+
+        result.PermanentLandHoldingIdentifier.Should().Be(permanentLandHoldingId);
+    }
+
+    [Fact]
+    public void ToDomain_WithNullPermanentLandHoldingIdentifier_ShouldBeNull()
+    {
+        var siteDocument = new SiteDocument
+        {
+            Id = "site-id",
+            Name = "Test Site",
+            StartDate = DateTime.UtcNow,
+            LastUpdatedDate = DateTime.UtcNow,
+            PermanentLandHoldingIdentifier = null
+        };
+
+        var result = siteDocument.ToDomain();
+
+        result.PermanentLandHoldingIdentifier.Should().BeNull();
+    }
+
     private static SiteActivityDocument MakeSiteActivityDocument(string id, string patId = "pat-id", string patCode = "pat-code", string patName = "pat-name")
     {
         return new SiteActivityDocument() { IdentifierId = id, Type = new SiteActivityTypeSummaryDocument() { IdentifierId = patId, Code = patCode, Name = patName } };
@@ -55,7 +141,7 @@ public class SiteDocumentTests
     private static Site EmptySite(DateTime? lastUpdatedDate = null)
     {
         lastUpdatedDate ??= DateTime.MinValue;
-        return new Site("", DateTime.MinValue, lastUpdatedDate!.Value, "", DateTime.MinValue, null, null, null, null, false, null, null, null, null);
+        return new Site("", DateTime.MinValue, lastUpdatedDate!.Value, "", DateTime.MinValue, null, null, null, null, false, null, null, null, null, null);
     }
 
     private static SiteDocument EmptySiteDocument()

--- a/tests/KeeperData.Core.Tests.Unit/Domain/Sites/SiteParentSiteIdentifierAndHoldingTypeTests.cs
+++ b/tests/KeeperData.Core.Tests.Unit/Domain/Sites/SiteParentSiteIdentifierAndHoldingTypeTests.cs
@@ -32,7 +32,10 @@ public class SiteParentSiteIdentifierAndHoldingTypeTests
             null,
             false,
             parentSiteIdentifier,
-            holdingType);
+            holdingType,
+            null,
+            null,
+            null);
 
         // Assert
         site.ParentSiteIdentifier.Should().Be(parentSiteIdentifier);
@@ -62,6 +65,9 @@ public class SiteParentSiteIdentifierAndHoldingTypeTests
             null,
             false,
             null,
+            null,
+            null,
+            null,
             null);
 
         // Assert
@@ -85,7 +91,10 @@ public class SiteParentSiteIdentifierAndHoldingTypeTests
             null,
             false,
             "12/345/9999",
-            "PERMANENT");
+            "PERMANENT",
+            null,
+            null,
+            null);
 
         var newParentSiteIdentifier = "98/765/4321";
         var updateTime = DateTime.UtcNow.AddHours(1);
@@ -101,7 +110,8 @@ public class SiteParentSiteIdentifierAndHoldingTypeTests
             null,
             false,
             newParentSiteIdentifier,
-            "PERMANENT");
+            "PERMANENT",
+            null);
 
         // Assert
         site.ParentSiteIdentifier.Should().Be(newParentSiteIdentifier);
@@ -124,7 +134,10 @@ public class SiteParentSiteIdentifierAndHoldingTypeTests
             null,
             false,
             "12/345/9999",
-            "PERMANENT");
+            "PERMANENT",
+            null,
+            null,
+            null);
 
         var newHoldingType = "TEMPORARY";
         var updateTime = DateTime.UtcNow.AddHours(1);
@@ -140,7 +153,8 @@ public class SiteParentSiteIdentifierAndHoldingTypeTests
             null,
             false,
             "12/345/9999",
-            newHoldingType);
+            newHoldingType,
+            null);
 
         // Assert
         site.HoldingType.Should().Be(newHoldingType);
@@ -163,7 +177,10 @@ public class SiteParentSiteIdentifierAndHoldingTypeTests
             null,
             false,
             "12/345/9999",
-            "PERMANENT");
+            "PERMANENT",
+            null,
+            null,
+            null);
 
         var updateTime = DateTime.UtcNow.AddHours(1);
 
@@ -178,7 +195,8 @@ public class SiteParentSiteIdentifierAndHoldingTypeTests
             null,
             false,
             null,
-            "PERMANENT");
+            "PERMANENT",
+            null);
 
         // Assert
         site.ParentSiteIdentifier.Should().BeNull();
@@ -196,14 +214,17 @@ public class SiteParentSiteIdentifierAndHoldingTypeTests
             initialTime,
             initialTime,
             "Test Site",
-             startDate,
+            startDate,
             null,
             "Active",
             "SAM",
             null,
             false,
             "12/345/9999",
-            "PERMANENT");
+            "PERMANENT",
+            null,
+            null,
+            null);
 
         var updateTime = DateTime.UtcNow.AddHours(1);
 
@@ -218,7 +239,8 @@ public class SiteParentSiteIdentifierAndHoldingTypeTests
             null,
             false,
             "12/345/9999",
-            "PERMANENT");
+            "PERMANENT",
+            null);
 
         // Assert - LastUpdatedDate should NOT change because values are the same
         site.ParentSiteIdentifier.Should().Be("12/345/9999");
@@ -242,7 +264,10 @@ public class SiteParentSiteIdentifierAndHoldingTypeTests
             null,
             false,
             "12/345/9999",
-            "PERMANENT");
+            "PERMANENT",
+            null,
+            null,
+            null);
 
         // Act
         var document = SiteDocument.FromDomain(site);
@@ -267,6 +292,9 @@ public class SiteParentSiteIdentifierAndHoldingTypeTests
             "SAM",
             null,
             false,
+            null,
+            null,
+            null,
             null,
             null);
 
@@ -398,7 +426,10 @@ public class SiteParentSiteIdentifierAndHoldingTypeTests
             null,
             false,
             "12/345/9999",
-            "PERMANENT");
+            "PERMANENT",
+            null,
+            null,
+            null);
 
         // Act
         var document = SiteDocument.FromDomain(originalSite);
@@ -433,7 +464,10 @@ public class SiteParentSiteIdentifierAndHoldingTypeTests
             null,
             false,
             parentSiteIdentifier,
-            holdingType);
+            holdingType,
+            null,
+            null,
+            null);
 
         // Assert
         site.ParentSiteIdentifier.Should().Be(parentSiteIdentifier);
@@ -456,7 +490,10 @@ public class SiteParentSiteIdentifierAndHoldingTypeTests
             null,
             false,
             "12/345/9999",
-            "PERMANENT");
+            "PERMANENT",
+            null,
+            null,
+            null);
 
         site.ClearDomainEvents(); // Clear creation event
 
@@ -471,7 +508,8 @@ public class SiteParentSiteIdentifierAndHoldingTypeTests
             null,
             false,
             "98/765/4321", // Changed
-            "PERMANENT");
+            "PERMANENT",
+            null);
 
         // Assert
         site.DomainEvents.Should().HaveCount(1);
@@ -494,7 +532,10 @@ public class SiteParentSiteIdentifierAndHoldingTypeTests
             null,
             false,
             "12/345/9999",
-            "PERMANENT");
+            "PERMANENT",
+            null,
+            null,
+            null);
 
         site.ClearDomainEvents(); // Clear creation event
 
@@ -509,7 +550,8 @@ public class SiteParentSiteIdentifierAndHoldingTypeTests
             null,
             false,
             "12/345/9999",
-            "TEMPORARY"); // Changed
+            "TEMPORARY", // Changed
+            null);
 
         // Assert
         site.DomainEvents.Should().HaveCount(1);

--- a/tests/KeeperData.Core.Tests.Unit/Domain/Sites/SiteTests.cs
+++ b/tests/KeeperData.Core.Tests.Unit/Domain/Sites/SiteTests.cs
@@ -149,6 +149,214 @@ public class SiteTests
         sut.Activities.Select(x => x.Id).Should().BeEquivalentTo(["act-2-id", "act-4-id"]);
     }
 
+    [Fact]
+    public void Create_WithPermanentLandHoldingIdentifier_ShouldSetProperty()
+    {
+        var permanentLandHoldingId = "12/345/9999";
+
+        var site = Site.Create(
+            "site-id",
+            DateTime.UtcNow,
+            DateTime.UtcNow,
+            "Test Site",
+            DateTime.UtcNow,
+            null,
+            null,
+            "SAM",
+            null,
+            false,
+            null,
+            "PERMANENT",
+            null,
+            null,
+            permanentLandHoldingId);
+
+        site.PermanentLandHoldingIdentifier.Should().Be(permanentLandHoldingId);
+    }
+
+    [Fact]
+    public void Create_WithNullPermanentLandHoldingIdentifier_ShouldBeNull()
+    {
+        var site = Site.Create(
+            "site-id",
+            DateTime.UtcNow,
+            DateTime.UtcNow,
+            "Test Site",
+            DateTime.UtcNow,
+            null,
+            null,
+            "SAM",
+            null,
+            false,
+            null,
+            "PERMANENT",
+            null,
+            null,
+            null);
+
+        site.PermanentLandHoldingIdentifier.Should().BeNull();
+    }
+
+    [Fact]
+    public void Update_WithDifferentPermanentLandHoldingIdentifier_ShouldUpdateProperty()
+    {
+        var oldLastUpdatedDate = new DateTime(2020, 1, 1);
+        var newLastUpdatedDate = new DateTime(2025, 1, 1);
+        var site = Site.Create(
+            "site-id",
+            oldLastUpdatedDate,
+            oldLastUpdatedDate,
+            "Test Site",
+            oldLastUpdatedDate,
+            null,
+            null,
+            "SAM",
+            null,
+            false,
+            null,
+            "PERMANENT",
+            null,
+            null,
+            "12/345/8888");
+
+        site.Update(
+            newLastUpdatedDate,
+            "Test Site",
+            oldLastUpdatedDate,
+            null,
+            null,
+            "SAM",
+            null,
+            false,
+            null,
+            "PERMANENT",
+            "12/345/9999");
+
+        site.PermanentLandHoldingIdentifier.Should().Be("12/345/9999");
+        site.LastUpdatedDate.Should().Be(newLastUpdatedDate);
+    }
+
+    [Fact]
+    public void Update_WithSamePermanentLandHoldingIdentifier_ShouldNotUpdateLastUpdatedDate()
+    {
+        var oldLastUpdatedDate = new DateTime(2020, 1, 1);
+        var newLastUpdatedDate = new DateTime(2025, 1, 1);
+        var permanentLandHoldingId = "12/345/9999";
+
+        var site = Site.Create(
+            "site-id",
+            oldLastUpdatedDate,
+            oldLastUpdatedDate,
+            "Test Site",
+            oldLastUpdatedDate,
+            null,
+            null,
+            "SAM",
+            null,
+            false,
+            null,
+            "PERMANENT",
+            null,
+            null,
+            permanentLandHoldingId);
+
+        site.Update(
+            newLastUpdatedDate,
+            "Test Site",
+            oldLastUpdatedDate,
+            null,
+            null,
+            "SAM",
+            null,
+            false,
+            null,
+            "PERMANENT",
+            permanentLandHoldingId);
+
+        site.PermanentLandHoldingIdentifier.Should().Be(permanentLandHoldingId);
+        site.LastUpdatedDate.Should().Be(oldLastUpdatedDate);
+    }
+
+    [Fact]
+    public void Update_ChangingFromNullToValue_ShouldUpdateProperty()
+    {
+        var oldLastUpdatedDate = new DateTime(2020, 1, 1);
+        var newLastUpdatedDate = new DateTime(2025, 1, 1);
+
+        var site = Site.Create(
+            "site-id",
+            oldLastUpdatedDate,
+            oldLastUpdatedDate,
+            "Test Site",
+            oldLastUpdatedDate,
+            null,
+            null,
+            "SAM",
+            null,
+            false,
+            null,
+            "PERMANENT",
+            null,
+            null,
+            null);
+
+        site.Update(
+            newLastUpdatedDate,
+            "Test Site",
+            oldLastUpdatedDate,
+            null,
+            null,
+            "SAM",
+            null,
+            false,
+            null,
+            "PERMANENT",
+            "12/345/9999");
+
+        site.PermanentLandHoldingIdentifier.Should().Be("12/345/9999");
+        site.LastUpdatedDate.Should().Be(newLastUpdatedDate);
+    }
+
+    [Fact]
+    public void Update_ChangingFromValueToNull_ShouldUpdateProperty()
+    {
+        var oldLastUpdatedDate = new DateTime(2020, 1, 1);
+        var newLastUpdatedDate = new DateTime(2025, 1, 1);
+
+        var site = Site.Create(
+            "site-id",
+            oldLastUpdatedDate,
+            oldLastUpdatedDate,
+            "Test Site",
+            oldLastUpdatedDate,
+            null,
+            null,
+            "SAM",
+            null,
+            false,
+            null,
+            "PERMANENT",
+            null,
+            null,
+            "12/345/9999");
+
+        site.Update(
+            newLastUpdatedDate,
+            "Test Site",
+            oldLastUpdatedDate,
+            null,
+            null,
+            "SAM",
+            null,
+            false,
+            null,
+            "PERMANENT",
+            null);
+
+        site.PermanentLandHoldingIdentifier.Should().BeNull();
+        site.LastUpdatedDate.Should().Be(newLastUpdatedDate);
+    }
+
     private static SiteActivity CreateSiteActivity(string actId)
     {
         return new SiteActivity(actId, new SiteActivityType("sat-id", null, "sat-code", "sat-name"), null, null, DateTime.MinValue);
@@ -156,6 +364,6 @@ public class SiteTests
 
     private static Site CreateSite(DateTime lastUpdatedDate, Location? location = null)
     {
-        return new Site("id", DateTime.MinValue, lastUpdatedDate, "site-name", DateTime.MinValue, null, null, null, null, false, null, location, null, null);
+        return new Site("id", DateTime.MinValue, lastUpdatedDate, "site-name", DateTime.MinValue, null, null, null, null, false, null, location, null, null, null);
     }
 }

--- a/tests/KeeperData.Core.Tests.Unit/Extensions/StringExtensionsTests.cs
+++ b/tests/KeeperData.Core.Tests.Unit/Extensions/StringExtensionsTests.cs
@@ -1,0 +1,23 @@
+using FluentAssertions;
+using KeeperData.Core.Extensions;
+
+namespace KeeperData.Core.Tests.Unit.Extensions;
+
+public class StringExtensionsTests
+{
+    [Theory]
+    [InlineData("PCPHLANDUSEDBYTCPH", true)]
+    [InlineData("pcphlandusedbytcph", true)]
+    [InlineData("PcPhLaNdUsEdByTcPh", true)]
+    [InlineData("PCPHLANDUSEDBYTCP", false)]
+    [InlineData("TCPH", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    [InlineData("   ", false)]
+    public void IsPermanentLandHolding_ShouldReturnExpectedResult(string? input, bool expected)
+    {
+        var result = input.IsPermanentLandHolding();
+
+        result.Should().Be(expected);
+    }
+}

--- a/tests/KeeperData.Core.Tests.Unit/KeeperData.Core.Tests.Unit.csproj
+++ b/tests/KeeperData.Core.Tests.Unit/KeeperData.Core.Tests.Unit.csproj
@@ -16,6 +16,10 @@
     </ItemGroup>
 
     <ItemGroup>
+      <Compile Include="Extensions\StringExtensionsTests.cs" />
+    </ItemGroup>
+
+    <ItemGroup>
       <PackageReference Include="FluentAssertions" Version="7.2.0" />
       <PackageReference Include="coverlet.collector" Version="6.0.4">
         <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Introduce PermanentLandHoldingIdentifier to Site, SiteDocument, and SiteDto.

Update SamHoldingMapper to set this property based on CphRelationshipType using a new IsPermanentLandHolding string extension. Update constructors, mapping logic, and tests to support the new property and ensure correct assignment between ParentSiteIdentifier and PermanentLandHoldingIdentifier.

Add unit tests for the extension and mapping logic. Update project file to include new tests.