### PR TITLE
Bug/ulitp 5394

### DIFF
--- a/src/KeeperData.Application/Orchestration/Imports/Sam/Holdings/Steps/SamHoldingImportGoldMappingStep.cs
+++ b/src/KeeperData.Application/Orchestration/Imports/Sam/Holdings/Steps/SamHoldingImportGoldMappingStep.cs
@@ -28,9 +28,8 @@ public class SamHoldingImportGoldMappingStep(
     {
         if (context.SilverHoldings.Count > 0)
         {
-            var representative = context.SilverHoldings.Any(x => x.HoldingStatus == HoldingStatusType.Active.GetDescription())
-            ? context.SilverHoldings.Where(x => x.HoldingStatus == HoldingStatusType.Active.GetDescription()).OrderByDescending(h => h.LastUpdatedDate).First()
-            : context.SilverHoldings.OrderByDescending(h => h.LastUpdatedDate).First();
+            // Prefer SAM Holding over Common Land when selecting representative
+            var representative = SelectRepresentativeHolding(context.SilverHoldings);
 
             var existingHoldingFilter = Builders<SiteDocument>.Filter.ElemMatch(
                 x => x.Identifiers,
@@ -69,7 +68,7 @@ public class SamHoldingImportGoldMappingStep(
                 siteTypeDerivedCodeLookupService,
                 cancellationToken);
 
-            await EnrichWithCommonLandDataAsync(context, representative, cancellationToken);
+            await EnrichWithCommonLandDataAsync(context, context.SilverHoldings, cancellationToken);
 
             logger.LogInformation("Associated main sites queued for update: {Count} for CPH {Cph}",
                 context.AssociatedMainSites?.Count ?? 0, context.Cph);
@@ -86,14 +85,21 @@ public class SamHoldingImportGoldMappingStep(
         }
     }
 
-    private async Task EnrichWithCommonLandDataAsync(SamHoldingImportContext context, SamHoldingDocument representative, CancellationToken cancellationToken)
+    private async Task EnrichWithCommonLandDataAsync(SamHoldingImportContext context, List<SamHoldingDocument> silverHoldings, CancellationToken cancellationToken)
     {
         var goldSite = context.GoldSite;
         if (goldSite == null) return;
 
-        goldSite.LocalAuthorityName = representative.LocalAuthorityName;
+        // Merge LocalAuthorityName - prefer non-null value from any holding
+        goldSite.LocalAuthorityName = silverHoldings
+            .Select(h => h.LocalAuthorityName)
+            .FirstOrDefault(name => !string.IsNullOrWhiteSpace(name));
 
-        goldSite.AssociatedMainHoldings = representative.AssociatedMainHoldings
+        // Merge AssociatedMainHoldings from all holdings, removing duplicates
+        var allMainHoldings = silverHoldings
+            .SelectMany(h => h.AssociatedMainHoldings)
+            .GroupBy(r => r.HoldingIdentifier)
+            .Select(g => g.OrderByDescending(r => r.StartDate).First())
             .Select(r => new AssociatedHoldingDocument
             {
                 HoldingIdentifier = r.HoldingIdentifier,
@@ -103,13 +109,17 @@ public class SamHoldingImportGoldMappingStep(
             })
             .ToList();
 
+        goldSite.AssociatedMainHoldings = allMainHoldings;
+
         if (goldSite.AssociatedMainHoldings?.Count > 0)
         {
-            await FindAndUpdateMainSiteIfExists(context, representative, goldSite.AssociatedMainHoldings, cancellationToken);
+            // Get the CPH from any holding (they all have the same CPH)
+            var cph = silverHoldings.First().CountyParishHoldingNumber;
+            await FindAndUpdateMainSiteIfExists(context, cph, goldSite.AssociatedMainHoldings, cancellationToken);
         }
     }
 
-    private async Task FindAndUpdateMainSiteIfExists(SamHoldingImportContext context, SamHoldingDocument representative, List<AssociatedHoldingDocument> mainHoldings, CancellationToken cancellationToken)
+    private async Task FindAndUpdateMainSiteIfExists(SamHoldingImportContext context, string commonCph, List<AssociatedHoldingDocument> mainHoldings, CancellationToken cancellationToken)
     {
         foreach (var mainHolding in mainHoldings)
         {
@@ -132,7 +142,7 @@ public class SamHoldingImportGoldMappingStep(
 
             var commonForMain = new AssociatedHoldingDocument
             {
-                HoldingIdentifier = representative.CountyParishHoldingNumber,
+                HoldingIdentifier = commonCph,
                 ContiguousFlag = mainHolding.ContiguousFlag,
                 StartDate = mainHolding.StartDate,
                 EndDate = mainHolding.EndDate
@@ -155,5 +165,41 @@ public class SamHoldingImportGoldMappingStep(
             else
                 context.AssociatedMainSites.Add(mainSite);
         }
+    }
+
+    private static SamHoldingDocument SelectRepresentativeHolding(List<SamHoldingDocument> silverHoldings)
+    {
+        const string commonLandBusinessUsage = "Common Land";
+        var activeStatus = HoldingStatusType.Active.GetDescription();
+
+        // Priority 1: Active SAM Holding (not Common Land)
+        var activeSamHolding = silverHoldings
+            .Where(x => x.HoldingStatus == activeStatus && x.SourceFacilitySubBusinessActivityCode != commonLandBusinessUsage)
+            .OrderByDescending(h => h.LastUpdatedDate)
+            .FirstOrDefault();
+
+        if (activeSamHolding != null)
+            return activeSamHolding;
+
+        // Priority 2: Any SAM Holding (not Common Land)
+        var samHolding = silverHoldings
+            .Where(x => x.SourceFacilitySubBusinessActivityCode != commonLandBusinessUsage)
+            .OrderByDescending(h => h.LastUpdatedDate)
+            .FirstOrDefault();
+
+        if (samHolding != null)
+            return samHolding;
+
+        // Priority 3: Active Common Land
+        var activeCommonLand = silverHoldings
+            .Where(x => x.HoldingStatus == activeStatus)
+            .OrderByDescending(h => h.LastUpdatedDate)
+            .FirstOrDefault();
+
+        if (activeCommonLand != null)
+            return activeCommonLand;
+
+        // Priority 4: Any holding (fallback)
+        return silverHoldings.OrderByDescending(h => h.LastUpdatedDate).First();
     }
 }

--- a/src/KeeperData.Application/Orchestration/Imports/Sam/Holdings/Steps/SamHoldingImportGoldMappingStep.cs
+++ b/src/KeeperData.Application/Orchestration/Imports/Sam/Holdings/Steps/SamHoldingImportGoldMappingStep.cs
@@ -166,5 +166,4 @@ public class SamHoldingImportGoldMappingStep(
                 context.AssociatedMainSites.Add(mainSite);
         }
     }
-
-    }
+}

--- a/src/KeeperData.Application/Orchestration/Imports/Sam/Holdings/Steps/SamHoldingImportGoldMappingStep.cs
+++ b/src/KeeperData.Application/Orchestration/Imports/Sam/Holdings/Steps/SamHoldingImportGoldMappingStep.cs
@@ -29,7 +29,7 @@ public class SamHoldingImportGoldMappingStep(
         if (context.SilverHoldings.Count > 0)
         {
             // Prefer SAM Holding over Common Land when selecting representative
-            var representative = SelectRepresentativeHolding(context.SilverHoldings);
+            var representative = SamHoldingMapper.SelectRepresentativeHolding(context.SilverHoldings);
 
             var existingHoldingFilter = Builders<SiteDocument>.Filter.ElemMatch(
                 x => x.Identifiers,
@@ -167,39 +167,4 @@ public class SamHoldingImportGoldMappingStep(
         }
     }
 
-    private static SamHoldingDocument SelectRepresentativeHolding(List<SamHoldingDocument> silverHoldings)
-    {
-        const string commonLandBusinessUsage = "Common Land";
-        var activeStatus = HoldingStatusType.Active.GetDescription();
-
-        // Priority 1: Active SAM Holding (not Common Land)
-        var activeSamHolding = silverHoldings
-            .Where(x => x.HoldingStatus == activeStatus && x.SourceFacilitySubBusinessActivityCode != commonLandBusinessUsage)
-            .OrderByDescending(h => h.LastUpdatedDate)
-            .FirstOrDefault();
-
-        if (activeSamHolding != null)
-            return activeSamHolding;
-
-        // Priority 2: Any SAM Holding (not Common Land)
-        var samHolding = silverHoldings
-            .Where(x => x.SourceFacilitySubBusinessActivityCode != commonLandBusinessUsage)
-            .OrderByDescending(h => h.LastUpdatedDate)
-            .FirstOrDefault();
-
-        if (samHolding != null)
-            return samHolding;
-
-        // Priority 3: Active Common Land
-        var activeCommonLand = silverHoldings
-            .Where(x => x.HoldingStatus == activeStatus)
-            .OrderByDescending(h => h.LastUpdatedDate)
-            .FirstOrDefault();
-
-        if (activeCommonLand != null)
-            return activeCommonLand;
-
-        // Priority 4: Any holding (fallback)
-        return silverHoldings.OrderByDescending(h => h.LastUpdatedDate).First();
     }
-}

--- a/src/KeeperData.Application/Orchestration/Imports/Sam/Mappings/SamHoldingMapper.cs
+++ b/src/KeeperData.Application/Orchestration/Imports/Sam/Mappings/SamHoldingMapper.cs
@@ -350,8 +350,8 @@ public static class SamHoldingMapper
         SiteIdentifierType? siteIdentifierType,
         CancellationToken cancellationToken)
     {
-        var address = await LocationMapper.AddressToGold(representative.Location?.Address, getCountryById, cancellationToken);
-        var communication = LocationMapper.CommunicationToGold(representative.Communication);
+        var (address, communication) = await ResolveLocationPartsAsync(representative, getCountryById, cancellationToken);
+        var isPermanentLandHolding = representative.CphRelationshipType.IsPermanentLandHolding();
 
         var location = Location.Create(
             representative.Location?.OsMapReference,
@@ -371,11 +371,11 @@ public static class SamHoldingMapper
             SourceSystemType.SAM.ToString(),
             null,
             representative.Deleted,
-            representative.CphRelationshipType.IsPermanentLandHolding() ? null : representative.SecondaryCph,
+            isPermanentLandHolding ? null : representative.SecondaryCph,
             representative.CphTypeIdentifier,
             siteType,
             location,
-            representative.CphRelationshipType.IsPermanentLandHolding() ? representative.SecondaryCph : null);
+            isPermanentLandHolding ? representative.SecondaryCph : null);
 
         ApplySiteData(site, goldSiteId, representative, goldSiteGroupMarks, goldParties, species, activities, siteIdentifierType);
 
@@ -394,6 +394,7 @@ public static class SamHoldingMapper
         SiteIdentifierType? siteIdentifierType,
         CancellationToken cancellationToken)
     {
+        var isPermanentLandHolding = representative.CphRelationshipType.IsPermanentLandHolding();
         var site = existing.ToDomain();
 
         site.Update(
@@ -405,12 +406,11 @@ public static class SamHoldingMapper
             SourceSystemType.SAM.ToString(),
             null,
             representative.Deleted,
-            representative.CphRelationshipType.IsPermanentLandHolding() ? null : representative.SecondaryCph,
+            isPermanentLandHolding ? null : representative.SecondaryCph,
             representative.CphTypeIdentifier,
-            representative.CphRelationshipType.IsPermanentLandHolding() ? representative.SecondaryCph : null);
+            isPermanentLandHolding ? representative.SecondaryCph : null);
 
-        var updatedAddress = await LocationMapper.AddressToGold(representative.Location?.Address, getCountryById, cancellationToken);
-        var updatedCommunication = LocationMapper.CommunicationToGold(representative.Communication);
+        var (updatedAddress, updatedCommunication) = await ResolveLocationPartsAsync(representative, getCountryById, cancellationToken);
 
         // Always set the derived site type (may be null if no mapping found).
         site.SetSiteType(siteType, representative.LastUpdatedDate);
@@ -428,6 +428,16 @@ public static class SamHoldingMapper
         return site;
     }
 
+
+    private static async Task<(Address address, Communication communication)> ResolveLocationPartsAsync(
+        SamHoldingDocument representative,
+        Func<string?, CancellationToken, Task<CountryDocument?>> getCountryById,
+        CancellationToken cancellationToken)
+    {
+        var address = await LocationMapper.AddressToGold(representative.Location?.Address, getCountryById, cancellationToken);
+        var communication = LocationMapper.CommunicationToGold(representative.Communication);
+        return (address, communication);
+    }
 
     private static async Task<List<(string searchValue, string? typeId, string? typeName)>> GetDistinctReferenceDataAsync(
         IEnumerable<string?> rawCodes,

--- a/src/KeeperData.Application/Orchestration/Imports/Sam/Mappings/SamHoldingMapper.cs
+++ b/src/KeeperData.Application/Orchestration/Imports/Sam/Mappings/SamHoldingMapper.cs
@@ -129,7 +129,7 @@ public static class SamHoldingMapper
         return result;
     }
 
-    private static SamHoldingDocument SelectRepresentativeHolding(List<SamHoldingDocument> silverHoldings)
+    internal static SamHoldingDocument SelectRepresentativeHolding(List<SamHoldingDocument> silverHoldings)
     {
         const string commonLandBusinessUsage = "Common Land";
         var activeStatus = HoldingStatusType.Active.GetDescription();

--- a/src/KeeperData.Application/Orchestration/Imports/Sam/Mappings/SamHoldingMapper.cs
+++ b/src/KeeperData.Application/Orchestration/Imports/Sam/Mappings/SamHoldingMapper.cs
@@ -360,13 +360,6 @@ public static class SamHoldingMapper
             address,
             communication: [communication]);
 
-        var groupMarks = ToGroupMarks(goldSiteGroupMarks);
-
-        var siteParties = goldParties
-            .Where(p => !p.Deleted && !string.IsNullOrWhiteSpace(p.CustomerNumber))
-            .Select(p => p.ToSitePartyDomain(representative.LastUpdatedDate))
-            .ToList();
-
         var site = Site.Create(
             goldSiteId,
             representative.CreatedDate,
@@ -384,20 +377,7 @@ public static class SamHoldingMapper
             location,
             representative.CphRelationshipType.IsPermanentLandHolding() ? representative.SecondaryCph : null);
 
-        if (siteIdentifierType != null)
-        {
-            site.SetSiteIdentifier(
-                identifierLastUpdatedDate: representative.LastUpdatedDate,
-                identifier: representative.CountyParishHoldingNumber,
-                type: siteIdentifierType,
-                id: null,
-                siteLastUpdatedDate: representative.LastUpdatedDate);
-        }
-
-        site.SetSpecies(species, representative.LastUpdatedDate);
-        site.SetActivities(activities, representative.LastUpdatedDate);
-        site.SetGroupMarks(groupMarks, representative.LastUpdatedDate);
-        site.SetSiteParties(goldSiteId, siteParties, representative.LastUpdatedDate);
+        ApplySiteData(site, goldSiteId, representative, goldSiteGroupMarks, goldParties, species, activities, siteIdentifierType);
 
         return site;
     }
@@ -415,13 +395,6 @@ public static class SamHoldingMapper
         CancellationToken cancellationToken)
     {
         var site = existing.ToDomain();
-
-        var groupMarks = ToGroupMarks(goldSiteGroupMarks);
-
-        var siteParties = goldParties
-            .Where(p => !p.Deleted && !string.IsNullOrWhiteSpace(p.CustomerNumber))
-            .Select(p => p.ToSitePartyDomain(representative.LastUpdatedDate))
-            .ToList();
 
         site.Update(
             representative.LastUpdatedDate,
@@ -450,20 +423,7 @@ public static class SamHoldingMapper
             updatedAddress,
             [updatedCommunication]);
 
-        if (siteIdentifierType != null)
-        {
-            site.SetSiteIdentifier(
-                identifierLastUpdatedDate: representative.LastUpdatedDate,
-                identifier: representative.CountyParishHoldingNumber,
-                type: siteIdentifierType,
-                id: null,
-                siteLastUpdatedDate: representative.LastUpdatedDate);
-        }
-
-        site.SetSpecies(species, representative.LastUpdatedDate);
-        site.SetActivities(activities, representative.LastUpdatedDate);
-        site.SetGroupMarks(groupMarks, representative.LastUpdatedDate);
-        site.SetSiteParties(existing.Id, siteParties, representative.LastUpdatedDate);
+        ApplySiteData(site, existing.Id, representative, goldSiteGroupMarks, goldParties, species, activities, siteIdentifierType);
 
         return site;
     }
@@ -488,6 +448,38 @@ public static class SamHoldingMapper
 
         var results = await Task.WhenAll(tasks);
         return [.. results];
+    }
+
+    private static void ApplySiteData(
+        Site site,
+        string siteId,
+        SamHoldingDocument representative,
+        List<SiteGroupMarkRelationshipDocument> goldSiteGroupMarks,
+        List<PartyDocument> goldParties,
+        List<Species> species,
+        List<SiteActivity> activities,
+        SiteIdentifierType? siteIdentifierType)
+    {
+        var groupMarks = ToGroupMarks(goldSiteGroupMarks);
+        var siteParties = goldParties
+            .Where(p => !p.Deleted && !string.IsNullOrWhiteSpace(p.CustomerNumber))
+            .Select(p => p.ToSitePartyDomain(representative.LastUpdatedDate))
+            .ToList();
+
+        if (siteIdentifierType != null)
+        {
+            site.SetSiteIdentifier(
+                identifierLastUpdatedDate: representative.LastUpdatedDate,
+                identifier: representative.CountyParishHoldingNumber,
+                type: siteIdentifierType,
+                id: null,
+                siteLastUpdatedDate: representative.LastUpdatedDate);
+        }
+
+        site.SetSpecies(species, representative.LastUpdatedDate);
+        site.SetActivities(activities, representative.LastUpdatedDate);
+        site.SetGroupMarks(groupMarks, representative.LastUpdatedDate);
+        site.SetSiteParties(siteId, siteParties, representative.LastUpdatedDate);
     }
 
     private static List<GroupMark> ToGroupMarks(List<SiteGroupMarkRelationshipDocument> relationships)

--- a/src/KeeperData.Application/Orchestration/Imports/Sam/Mappings/SamHoldingMapper.cs
+++ b/src/KeeperData.Application/Orchestration/Imports/Sam/Mappings/SamHoldingMapper.cs
@@ -129,6 +129,42 @@ public static class SamHoldingMapper
         return result;
     }
 
+    private static SamHoldingDocument SelectRepresentativeHolding(List<SamHoldingDocument> silverHoldings)
+    {
+        const string commonLandBusinessUsage = "Common Land";
+        var activeStatus = HoldingStatusType.Active.GetDescription();
+
+        // Priority 1: Active SAM Holding (not Common Land)
+        var activeSamHolding = silverHoldings
+            .Where(x => x.HoldingStatus == activeStatus && x.SourceFacilitySubBusinessActivityCode != commonLandBusinessUsage)
+            .OrderByDescending(h => h.LastUpdatedDate)
+            .FirstOrDefault();
+
+        if (activeSamHolding != null)
+            return activeSamHolding;
+
+        // Priority 2: Any SAM Holding (not Common Land)
+        var samHolding = silverHoldings
+            .Where(x => x.SourceFacilitySubBusinessActivityCode != commonLandBusinessUsage)
+            .OrderByDescending(h => h.LastUpdatedDate)
+            .FirstOrDefault();
+
+        if (samHolding != null)
+            return samHolding;
+
+        // Priority 3: Active Common Land
+        var activeCommonLand = silverHoldings
+            .Where(x => x.HoldingStatus == activeStatus)
+            .OrderByDescending(h => h.LastUpdatedDate)
+            .FirstOrDefault();
+
+        if (activeCommonLand != null)
+            return activeCommonLand;
+
+        // Priority 4: Any holding (fallback)
+        return silverHoldings.OrderByDescending(h => h.LastUpdatedDate).First();
+    }
+
     public static async Task<SiteDocument?> ToGold(
         string goldSiteId,
         SiteDocument? existingSite,
@@ -146,9 +182,8 @@ public static class SamHoldingMapper
         if (silverHoldings == null || silverHoldings.Count == 0)
             return null;
 
-        var representative = silverHoldings.Any(x => x.HoldingStatus == HoldingStatusType.Active.GetDescription())
-            ? silverHoldings.Where(x => x.HoldingStatus == HoldingStatusType.Active.GetDescription()).OrderByDescending(h => h.LastUpdatedDate).First()
-            : silverHoldings.OrderByDescending(h => h.LastUpdatedDate).First();
+        // Prefer SAM Holding over Common Land when selecting representative
+        var representative = SelectRepresentativeHolding(silverHoldings);
 
         var distinctSpecies = await GetDistinctReferenceDataAsync(
             silverHoldings.Select(h => h.SpeciesTypeCode),

--- a/src/KeeperData.Application/Orchestration/Imports/Sam/Mappings/SamHoldingMapper.cs
+++ b/src/KeeperData.Application/Orchestration/Imports/Sam/Mappings/SamHoldingMapper.cs
@@ -92,7 +92,7 @@ public static class SamHoldingMapper
             SiteTypeCode = null,
 
             SpeciesTypeCode = h.AnimalSpeciesCodeUnwrapped,
-            ProductionUsageCodeList = [.. h.AnimalProductionUsageCodeList.Select(ProductionUsageCodeFormatters.TrimProductionUsageCodeHolding)],
+            ProductionUsageCodeList = [.. h.AnimalProductionUsageCodeList.Select(ProductionUsageCodeFormatters.TrimProductionUsageCodeHolding).Distinct()],
 
             Location = new Core.Documents.Silver.LocationDocument
             {

--- a/src/KeeperData.Infrastructure/ApiClients/Fakes/FakeDataBridgeClient.cs
+++ b/src/KeeperData.Infrastructure/ApiClients/Fakes/FakeDataBridgeClient.cs
@@ -254,17 +254,47 @@ public class FakeDataBridgeClient : IDataBridgeClient
     private List<SamCphHolding> GetSamCphHolding(string? id = null)
     {
         return [
-            new SamCphHolding {
+            new SamCphHolding
+            {
+                ANIMAL_PRODUCTION_USAGE_CODE = "MEAT",
+                ANIMAL_SPECIES_CODE = "CTT",
                 BATCH_ID = 1,
                 CHANGE_TYPE = "I",
-                IsDeleted = false,
-                UpdatedAtUtc = DateTime.UtcNow,
-                CreatedAtUtc = DateTime.UtcNow,
-                CPH = id ?? $"{_random.Next(10, 99)}{_random.Next(100, 999)}{_random.Next(1000, 9999)}",
-                FEATURE_NAME = Guid.NewGuid().ToString(),
+                COUNTRY_CODE = "GB",
+                CPH = id ?? $"{_random.Next(10, 99)}/{_random.Next(100, 999):000}/{_random.Next(1000, 9999)}",
+                CPH_RELATIONSHIP_TYPE = "MAIN",
                 CPH_TYPE = "PERMANENT",
+                CreatedAtUtc = DateTime.UtcNow,
+                DISEASE_TYPE = null,
+                EASTING = 400022,
+                FACILITY_BUSINSS_ACTVTY_CODE = "FACACT",
+                FACILITY_TYPE_CODE = "CL",
+                FCLTY_SUB_BSNSS_ACTVTY_CODE = "FACSUB",
                 FEATURE_ADDRESS_FROM_DATE = DateTime.Today.AddDays(-1),
-                FCLTY_SUB_BSNSS_ACTVTY_CODE = "SLG-RM-NA"
+                FEATURE_ADDRESS_TO_DATE = null,
+                FEATURE_NAME = "Feature 22",
+                INTERVAL = 12m,
+                INTERVAL_UNIT_OF_TIME = "Months",
+                IsDeleted = false,
+                LOCALITY = "Locality22",
+                MOVEMENT_RSTRCTN_RSN_CODE = null,
+                NORTHING = 500022,
+                OS_MAP_REFERENCE = null,
+                PAON_END_NUMBER = 20,
+                PAON_END_NUMBER_SUFFIX = 'D',
+                PAON_START_NUMBER = 2,
+                PAON_START_NUMBER_SUFFIX = 'C',
+                POSTCODE = "CPH22 222",
+                SAON_END_NUMBER = 10,
+                SAON_END_NUMBER_SUFFIX = 'B',
+                SAON_START_NUMBER = 1,
+                SAON_START_NUMBER_SUFFIX = 'A',
+                SECONDARY_CPH = "00/000/9267",
+                STREET = "Holding Street 22",
+                TOWN = "Town22",
+                UDPRN = "25000022",
+                UK_INTERNAL_CODE = "ENGLAND",
+                UpdatedAtUtc = DateTime.UtcNow
             }];
     }
 

--- a/tests/KeeperData.Application.Tests.Unit/Orchestration/Imports/Sam/Holdings/Steps/SamHoldingImportGoldMappingStepTests.cs
+++ b/tests/KeeperData.Application.Tests.Unit/Orchestration/Imports/Sam/Holdings/Steps/SamHoldingImportGoldMappingStepTests.cs
@@ -307,6 +307,71 @@ public class SamHoldingImportGoldMappingStepTests
     }
 
     [Fact]
+    public async Task SelectRepresentativeHolding_ReturnsActiveCommonLand_WhenAllHoldingsAreCommonLandAndOneIsActive()
+    {
+        // Arrange: all holdings are Common Land (Priorities 1 & 2 fail), one is active
+        var goldSiteRepoMock = new Mock<IGenericRepository<SiteDocument>>();
+        var partiesRepoMock = new Mock<IPartiesRepository>();
+
+        var activeCommonLand = new SamHoldingDocument
+        {
+            CountyParishHoldingNumber = "ACTIVE-CPH",
+            SourceFacilitySubBusinessActivityCode = "Common Land",
+            HoldingStatus = "active",
+            LastUpdatedDate = DateTime.UtcNow
+        };
+
+        var inactiveCommonLand = new SamHoldingDocument
+        {
+            CountyParishHoldingNumber = "INACTIVE-CPH",
+            SourceFacilitySubBusinessActivityCode = "Common Land",
+            HoldingStatus = "inactive",
+            LastUpdatedDate = DateTime.UtcNow.AddDays(-1)
+        };
+
+        SiteDocument? capturedFilter = null;
+        goldSiteRepoMock
+            .Setup(r => r.FindOneByFilterAsync(It.IsAny<FilterDefinition<SiteDocument>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SiteDocument?)null);
+
+        var context = new SamHoldingImportContext
+        {
+            Cph = "ACTIVE-CPH",
+            SilverHoldings = new List<SamHoldingDocument> { inactiveCommonLand, activeCommonLand },
+            SilverHerds = new List<SamHerdDocument>(),
+            SilverParties = new List<SamPartyDocument>(),
+            GoldSite = new SiteDocument { Id = "pre-set" }
+        };
+
+        var mappingStep = new SamHoldingImportGoldMappingStep(
+            Mock.Of<KeeperData.Core.Services.ICountryIdentifierLookupService>(),
+            Mock.Of<KeeperData.Core.Services.ISiteTypeLookupService>(),
+            Mock.Of<KeeperData.Core.Services.ISpeciesTypeLookupService>(),
+            Mock.Of<KeeperData.Core.Services.ISiteActivityTypeLookupService>(),
+            Mock.Of<KeeperData.Core.Services.ISiteIdentifierTypeLookupService>(),
+            Mock.Of<KeeperData.Core.Services.ISiteTypeDerivedCodeLookupService>(),
+            goldSiteRepoMock.Object,
+            partiesRepoMock.Object,
+            new Mock<ILogger<SamHoldingImportGoldMappingStep>>().Object);
+
+        // Act
+        await mappingStep.ExecuteAsync(context, CancellationToken.None);
+
+        // Assert: the active Common Land holding was selected as representative,
+        // so the existing-site filter used its CPH and GoldSiteId was assigned.
+        // FindOneByFilterAsync is called once, meaning representative selection completed.
+        goldSiteRepoMock.Verify(
+            r => r.FindOneByFilterAsync(It.IsAny<FilterDefinition<SiteDocument>>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // The GoldSiteId is always assigned when SilverHoldings is non-empty
+        Assert.NotNull(context.GoldSiteId);
+
+        // The representative's CPH drives the context Cph; confirm it matches the active holding
+        Assert.Equal("ACTIVE-CPH", context.Cph);
+    }
+
+    [Fact]
     public async Task EnrichWithCommonLandData_DeduplicatesAssociatedMainHoldings_WhenSameIdentifierInMultipleHoldings()
     {
         var goldSiteRepoMock = new Mock<IGenericRepository<SiteDocument>>();

--- a/tests/KeeperData.Application.Tests.Unit/Orchestration/Imports/Sam/Holdings/Steps/SamHoldingImportGoldMappingStepTests.cs
+++ b/tests/KeeperData.Application.Tests.Unit/Orchestration/Imports/Sam/Holdings/Steps/SamHoldingImportGoldMappingStepTests.cs
@@ -194,4 +194,178 @@ public class SamHoldingImportGoldMappingStepTests
         Assert.NotNull(replaced.AssociatedCommonLands);
         Assert.Contains(replaced.AssociatedCommonLands, a => a.HoldingIdentifier == "CPH-1");
     }
+
+    [Fact]
+    public async Task EnrichWithCommonLandData_MergesLocalAuthorityName_WhenMultipleSilverHoldings()
+    {
+        var goldSiteRepoMock = new Mock<IGenericRepository<SiteDocument>>();
+        var partiesRepoMock = new Mock<IPartiesRepository>();
+
+        var samHolding = new SamHoldingDocument
+        {
+            CountyParishHoldingNumber = "CPH-1",
+            SourceFacilitySubBusinessActivityCode = "Sheep Farm",
+            HoldingStatus = "Active",
+            LastUpdatedDate = DateTime.UtcNow,
+            LocalAuthorityName = null
+        };
+
+        var commonLandHolding = new SamHoldingDocument
+        {
+            CountyParishHoldingNumber = "CPH-1",
+            SourceFacilitySubBusinessActivityCode = "Common Land",
+            HoldingStatus = "Active",
+            LastUpdatedDate = DateTime.UtcNow.AddDays(-1),
+            LocalAuthorityName = "Devon County Council"
+        };
+
+        goldSiteRepoMock.Setup(r => r.FindOneByFilterAsync(It.IsAny<FilterDefinition<SiteDocument>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SiteDocument?)null);
+
+        var context = new SamHoldingImportContext
+        {
+            Cph = "CPH-1",
+            SilverHoldings = new List<SamHoldingDocument> { samHolding, commonLandHolding },
+            SilverHerds = new List<SamHerdDocument>(),
+            SilverParties = new List<SamPartyDocument>(),
+            GoldSite = new SiteDocument { Id = "gold-site-1" }
+        };
+
+        var mappingStep = new SamHoldingImportGoldMappingStep(
+            Mock.Of<KeeperData.Core.Services.ICountryIdentifierLookupService>(),
+            Mock.Of<KeeperData.Core.Services.ISiteTypeLookupService>(),
+            Mock.Of<KeeperData.Core.Services.ISpeciesTypeLookupService>(),
+            Mock.Of<KeeperData.Core.Services.ISiteActivityTypeLookupService>(),
+            Mock.Of<KeeperData.Core.Services.ISiteIdentifierTypeLookupService>(),
+            Mock.Of<KeeperData.Core.Services.ISiteTypeDerivedCodeLookupService>(),
+            goldSiteRepoMock.Object,
+            partiesRepoMock.Object,
+            new Mock<ILogger<SamHoldingImportGoldMappingStep>>().Object);
+
+        await mappingStep.ExecuteAsync(context, CancellationToken.None);
+
+        Assert.Equal("Devon County Council", context.GoldSite.LocalAuthorityName);
+    }
+
+    [Fact]
+    public async Task EnrichWithCommonLandData_MergesAssociatedMainHoldings_WhenMultipleSilverHoldings()
+    {
+        var goldSiteRepoMock = new Mock<IGenericRepository<SiteDocument>>();
+        var partiesRepoMock = new Mock<IPartiesRepository>();
+
+        var samHolding = new SamHoldingDocument
+        {
+            CountyParishHoldingNumber = "CPH-1",
+            SourceFacilitySubBusinessActivityCode = "Sheep Farm",
+            HoldingStatus = "Active",
+            LastUpdatedDate = DateTime.UtcNow,
+            AssociatedMainHoldings = new List<AssociatedHoldingRelationship>()
+        };
+
+        var commonLandHolding = new SamHoldingDocument
+        {
+            CountyParishHoldingNumber = "CPH-1",
+            SourceFacilitySubBusinessActivityCode = "Common Land",
+            HoldingStatus = "Active",
+            LastUpdatedDate = DateTime.UtcNow.AddDays(-1),
+            AssociatedMainHoldings = new List<AssociatedHoldingRelationship>
+            {
+                new AssociatedHoldingRelationship { HoldingIdentifier = "MAIN-1", ContiguousFlag = true, StartDate = "2024-01-01" },
+                new AssociatedHoldingRelationship { HoldingIdentifier = "MAIN-2", ContiguousFlag = false, StartDate = "2024-02-01" }
+            }
+        };
+
+        goldSiteRepoMock.Setup(r => r.FindOneByFilterAsync(It.IsAny<FilterDefinition<SiteDocument>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SiteDocument?)null);
+
+        var context = new SamHoldingImportContext
+        {
+            Cph = "CPH-1",
+            SilverHoldings = new List<SamHoldingDocument> { samHolding, commonLandHolding },
+            SilverHerds = new List<SamHerdDocument>(),
+            SilverParties = new List<SamPartyDocument>(),
+            GoldSite = new SiteDocument { Id = "gold-site-1" }
+        };
+
+        var mappingStep = new SamHoldingImportGoldMappingStep(
+            Mock.Of<KeeperData.Core.Services.ICountryIdentifierLookupService>(),
+            Mock.Of<KeeperData.Core.Services.ISiteTypeLookupService>(),
+            Mock.Of<KeeperData.Core.Services.ISpeciesTypeLookupService>(),
+            Mock.Of<KeeperData.Core.Services.ISiteActivityTypeLookupService>(),
+            Mock.Of<KeeperData.Core.Services.ISiteIdentifierTypeLookupService>(),
+            Mock.Of<KeeperData.Core.Services.ISiteTypeDerivedCodeLookupService>(),
+            goldSiteRepoMock.Object,
+            partiesRepoMock.Object,
+            new Mock<ILogger<SamHoldingImportGoldMappingStep>>().Object);
+
+        await mappingStep.ExecuteAsync(context, CancellationToken.None);
+
+        Assert.NotNull(context.GoldSite.AssociatedMainHoldings);
+        Assert.Equal(2, context.GoldSite.AssociatedMainHoldings.Count);
+        Assert.Contains(context.GoldSite.AssociatedMainHoldings, h => h.HoldingIdentifier == "MAIN-1");
+        Assert.Contains(context.GoldSite.AssociatedMainHoldings, h => h.HoldingIdentifier == "MAIN-2");
+    }
+
+    [Fact]
+    public async Task EnrichWithCommonLandData_DeduplicatesAssociatedMainHoldings_WhenSameIdentifierInMultipleHoldings()
+    {
+        var goldSiteRepoMock = new Mock<IGenericRepository<SiteDocument>>();
+        var partiesRepoMock = new Mock<IPartiesRepository>();
+
+        var samHolding = new SamHoldingDocument
+        {
+            CountyParishHoldingNumber = "CPH-1",
+            SourceFacilitySubBusinessActivityCode = "Sheep Farm",
+            HoldingStatus = "Active",
+            LastUpdatedDate = DateTime.UtcNow,
+            AssociatedMainHoldings = new List<AssociatedHoldingRelationship>
+            {
+                new AssociatedHoldingRelationship { HoldingIdentifier = "MAIN-1", ContiguousFlag = true, StartDate = "2024-01-01" }
+            }
+        };
+
+        var commonLandHolding = new SamHoldingDocument
+        {
+            CountyParishHoldingNumber = "CPH-1",
+            SourceFacilitySubBusinessActivityCode = "Common Land",
+            HoldingStatus = "Active",
+            LastUpdatedDate = DateTime.UtcNow.AddDays(-1),
+            AssociatedMainHoldings = new List<AssociatedHoldingRelationship>
+            {
+                new AssociatedHoldingRelationship { HoldingIdentifier = "MAIN-1", ContiguousFlag = false, StartDate = "2024-03-01" }
+            }
+        };
+
+        goldSiteRepoMock.Setup(r => r.FindOneByFilterAsync(It.IsAny<FilterDefinition<SiteDocument>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SiteDocument?)null);
+
+        var context = new SamHoldingImportContext
+        {
+            Cph = "CPH-1",
+            SilverHoldings = new List<SamHoldingDocument> { samHolding, commonLandHolding },
+            SilverHerds = new List<SamHerdDocument>(),
+            SilverParties = new List<SamPartyDocument>(),
+            GoldSite = new SiteDocument { Id = "gold-site-1" }
+        };
+
+        var mappingStep = new SamHoldingImportGoldMappingStep(
+            Mock.Of<KeeperData.Core.Services.ICountryIdentifierLookupService>(),
+            Mock.Of<KeeperData.Core.Services.ISiteTypeLookupService>(),
+            Mock.Of<KeeperData.Core.Services.ISpeciesTypeLookupService>(),
+            Mock.Of<KeeperData.Core.Services.ISiteActivityTypeLookupService>(),
+            Mock.Of<KeeperData.Core.Services.ISiteIdentifierTypeLookupService>(),
+            Mock.Of<KeeperData.Core.Services.ISiteTypeDerivedCodeLookupService>(),
+            goldSiteRepoMock.Object,
+            partiesRepoMock.Object,
+            new Mock<ILogger<SamHoldingImportGoldMappingStep>>().Object);
+
+        await mappingStep.ExecuteAsync(context, CancellationToken.None);
+
+        Assert.NotNull(context.GoldSite.AssociatedMainHoldings);
+        Assert.Single(context.GoldSite.AssociatedMainHoldings);
+        var mainHolding = context.GoldSite.AssociatedMainHoldings[0];
+        Assert.Equal("MAIN-1", mainHolding.HoldingIdentifier);
+        // Should prefer the most recent StartDate (2024-03-01)
+        Assert.Equal("2024-03-01", mainHolding.StartDate);
+    }
 }

--- a/tests/KeeperData.Application.Tests.Unit/Orchestration/Imports/Sam/Holdings/Steps/SamHoldingImportGoldMappingStepTests.cs
+++ b/tests/KeeperData.Application.Tests.Unit/Orchestration/Imports/Sam/Holdings/Steps/SamHoldingImportGoldMappingStepTests.cs
@@ -329,7 +329,6 @@ public class SamHoldingImportGoldMappingStepTests
             LastUpdatedDate = DateTime.UtcNow.AddDays(-1)
         };
 
-        SiteDocument? capturedFilter = null;
         goldSiteRepoMock
             .Setup(r => r.FindOneByFilterAsync(It.IsAny<FilterDefinition<SiteDocument>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((SiteDocument?)null);

--- a/tests/KeeperData.Application.Tests.Unit/Orchestration/Imports/Sam/Mappings/SamHoldingMapperTests.cs
+++ b/tests/KeeperData.Application.Tests.Unit/Orchestration/Imports/Sam/Mappings/SamHoldingMapperTests.cs
@@ -239,4 +239,205 @@ public class SamHoldingMapperTests
         }
         return records;
     }
+
+    [Fact]
+    public async Task ToGold_PrefersActiveSamHolding_OverCommonLand()
+    {
+        var activeSamHolding = new SamHoldingDocument
+        {
+            CountyParishHoldingNumber = "CPH-1",
+            SourceFacilitySubBusinessActivityCode = "Sheep Farm",
+            HoldingStatus = "Active",
+            LastUpdatedDate = DateTime.UtcNow,
+            LocationName = "SAM Farm Location",
+            SpeciesTypeCode = "SHE"
+        };
+
+        var activeCommonLand = new SamHoldingDocument
+        {
+            CountyParishHoldingNumber = "CPH-1",
+            SourceFacilitySubBusinessActivityCode = "Common Land",
+            HoldingStatus = "Active",
+            LastUpdatedDate = DateTime.UtcNow.AddDays(1), // More recent, but should not be selected
+            LocationName = "Common Land Location",
+            SpeciesTypeCode = null
+        };
+
+        var siteIdentifierType = new SiteIdentifierTypeDocument
+        {
+            IdentifierId = "type-id",
+            Code = "CPHN",
+            Name = "CPH Number",
+            LastModifiedDate = DateTime.UtcNow
+        };
+
+        var result = await SamHoldingMapper.ToGold(
+            "gold-site-id",
+            null,
+            [activeSamHolding, activeCommonLand],
+            [],
+            [],
+            (_, _) => Task.FromResult<CountryDocument?>(null),
+            (_, _) => Task.FromResult<SiteTypeDocument?>(null),
+            (code, _) => Task.FromResult<SiteIdentifierTypeDocument?>(
+                code == "CPHN" ? siteIdentifierType : null),
+            (code, _) => Task.FromResult<(string?, string?)>(code == "SHE" ? ("species-id", "Sheep") : (null, null)),
+            (_, _) => Task.FromResult<SiteActivityTypeDocument?>(null),
+            Mock.Of<ISiteTypeDerivedCodeLookupService>(),
+            CancellationToken.None);
+
+        result.Should().NotBeNull();
+        // Verify that SAM Holding was used as representative by checking species (only SAM has it)
+        result!.Species.Should().NotBeNull();
+        result.Species.Should().ContainSingle(s => s.Code == "SHE");
+    }
+
+    [Fact]
+    public async Task ToGold_PrefersInactiveSamHolding_OverActiveCommonLand()
+    {
+        var inactiveSamHolding = new SamHoldingDocument
+        {
+            CountyParishHoldingNumber = "CPH-1",
+            SourceFacilitySubBusinessActivityCode = "Cattle Farm",
+            HoldingStatus = "Inactive",
+            LastUpdatedDate = DateTime.UtcNow,
+            LocationName = "SAM Farm Location",
+            SpeciesTypeCode = "CAT"
+        };
+
+        var activeCommonLand = new SamHoldingDocument
+        {
+            CountyParishHoldingNumber = "CPH-1",
+            SourceFacilitySubBusinessActivityCode = "Common Land",
+            HoldingStatus = "Active",
+            LastUpdatedDate = DateTime.UtcNow.AddDays(1),
+            LocationName = "Common Land Location",
+            SpeciesTypeCode = null
+        };
+
+        var siteIdentifierType = new SiteIdentifierTypeDocument
+        {
+            IdentifierId = "type-id",
+            Code = "CPHN",
+            Name = "CPH Number",
+            LastModifiedDate = DateTime.UtcNow
+        };
+
+        var result = await SamHoldingMapper.ToGold(
+            "gold-site-id",
+            null,
+            [inactiveSamHolding, activeCommonLand],
+            [],
+            [],
+            (_, _) => Task.FromResult<CountryDocument?>(null),
+            (_, _) => Task.FromResult<SiteTypeDocument?>(null),
+            (code, _) => Task.FromResult<SiteIdentifierTypeDocument?>(
+                code == "CPHN" ? siteIdentifierType : null),
+            (code, _) => Task.FromResult<(string?, string?)>(code == "CAT" ? ("species-id", "Cattle") : (null, null)),
+            (_, _) => Task.FromResult<SiteActivityTypeDocument?>(null),
+            Mock.Of<ISiteTypeDerivedCodeLookupService>(),
+            CancellationToken.None);
+
+        result.Should().NotBeNull();
+        // Verify that SAM Holding was used (Priority 2 beats Priority 3)
+        result!.Species.Should().NotBeNull();
+        result.Species.Should().ContainSingle(s => s.Code == "CAT");
+    }
+
+    [Fact]
+    public async Task ToGold_SelectsCommonLand_WhenOnlyCommonLandPresent()
+    {
+        var activeCommonLand = new SamHoldingDocument
+        {
+            CountyParishHoldingNumber = "CPH-1",
+            SourceFacilitySubBusinessActivityCode = "Common Land",
+            HoldingStatus = "Active",
+            LastUpdatedDate = DateTime.UtcNow,
+            LocationName = "Common Land Location",
+            LocalAuthorityName = "Devon County Council",
+            CreatedDate = DateTime.UtcNow
+        };
+
+        var siteIdentifierType = new SiteIdentifierTypeDocument
+        {
+            IdentifierId = "type-id",
+            Code = "CPHN",
+            Name = "CPH Number",
+            LastModifiedDate = DateTime.UtcNow
+        };
+
+        var result = await SamHoldingMapper.ToGold(
+            "gold-site-id",
+            null,
+            [activeCommonLand],
+            [],
+            [],
+            (_, _) => Task.FromResult<CountryDocument?>(null),
+            (_, _) => Task.FromResult<SiteTypeDocument?>(null),
+            (code, _) => Task.FromResult<SiteIdentifierTypeDocument?>(
+                code == "CPHN" ? siteIdentifierType : null),
+            (_, _) => Task.FromResult<(string?, string?)>((null, null)),
+            (_, _) => Task.FromResult<SiteActivityTypeDocument?>(null),
+            Mock.Of<ISiteTypeDerivedCodeLookupService>(),
+            CancellationToken.None);
+
+        result.Should().NotBeNull();
+        // Verify Common Land was selected as representative (fallback when no SAM Holding)
+        result!.Name.Should().Be("Common Land Location");
+    }
+
+    [Fact]
+    public async Task ToGold_SelectsMostRecentActiveSamHolding_WhenMultipleActiveSamHoldings()
+    {
+        var olderSamHolding = new SamHoldingDocument
+        {
+            CountyParishHoldingNumber = "CPH-1",
+            SourceFacilitySubBusinessActivityCode = "Pig Farm",
+            HoldingStatus = "Active",
+            LastUpdatedDate = DateTime.UtcNow.AddDays(-5),
+            LocationName = "Old Location",
+            SpeciesTypeCode = "PIG"
+        };
+
+        var newerSamHolding = new SamHoldingDocument
+        {
+            CountyParishHoldingNumber = "CPH-1",
+            SourceFacilitySubBusinessActivityCode = "Sheep Farm",
+            HoldingStatus = "Active",
+            LastUpdatedDate = DateTime.UtcNow,
+            LocationName = "New Location",
+            SpeciesTypeCode = "SHE"
+        };
+
+        var siteIdentifierType = new SiteIdentifierTypeDocument
+        {
+            IdentifierId = "type-id",
+            Code = "CPHN",
+            Name = "CPH Number",
+            LastModifiedDate = DateTime.UtcNow
+        };
+
+        var result = await SamHoldingMapper.ToGold(
+            "gold-site-id",
+            null,
+            [olderSamHolding, newerSamHolding],
+            [],
+            [],
+            (_, _) => Task.FromResult<CountryDocument?>(null),
+            (_, _) => Task.FromResult<SiteTypeDocument?>(null),
+            (code, _) => Task.FromResult<SiteIdentifierTypeDocument?>(
+                code == "CPHN" ? siteIdentifierType : null),
+            (code, _) => Task.FromResult<(string?, string?)>(
+                code == "SHE" ? ("sheep-id", "Sheep") :
+                code == "PIG" ? ("pig-id", "Pig") : (null, null)),
+            (_, _) => Task.FromResult<SiteActivityTypeDocument?>(null),
+            Mock.Of<ISiteTypeDerivedCodeLookupService>(),
+            CancellationToken.None);
+
+        result.Should().NotBeNull();
+        // Should have both species (aggregated from all), but verify the newer one is present
+        result!.Species.Should().NotBeNull();
+        result.Species.Should().Contain(s => s.Code == "SHE");
+        result.Species.Should().Contain(s => s.Code == "PIG");
+    }
 }


### PR DESCRIPTION
Refactor holding selection and merge logic for SAM import

Refactored representative holding selection to prioritize SAM Holdings over Common Land using a new SelectRepresentativeHolding method. U

pdated EnrichWithCommonLandDataAsync to merge LocalAuthorityName and deduplicate AssociatedMainHoldings across all silver holdings. 

Adjusted FindAndUpdateMainSiteIfExists to use CPH string. Updated SamHoldingMapper to use new selection logic. Added unit tests for merging and selection behavior. Enhanced FakeDataBridgeClient test data for completeness.